### PR TITLE
Add extended sequential and repeat

### DIFF
--- a/pytorch_pfn_extras/nn/__init__.py
+++ b/pytorch_pfn_extras/nn/__init__.py
@@ -2,3 +2,4 @@ from pytorch_pfn_extras.nn.modules.lazy_linear import LazyLinear  # NOQA
 from pytorch_pfn_extras.nn.modules.lazy_conv import LazyConv1d  # NOQA
 from pytorch_pfn_extras.nn.modules.lazy_conv import LazyConv2d  # NOQA
 from pytorch_pfn_extras.nn.modules.lazy_conv import LazyConv3d  # NOQA
+from pytorch_pfn_extras.nn.modules.extended_sequential import ExtendedSequential  # NOQA

--- a/pytorch_pfn_extras/nn/modules/extended_sequential.py
+++ b/pytorch_pfn_extras/nn/modules/extended_sequential.py
@@ -1,6 +1,5 @@
 import torch
 import copy
-from collections.abc import Iterable
 
 
 def _reset_parameters(model):

--- a/pytorch_pfn_extras/nn/modules/extended_sequential.py
+++ b/pytorch_pfn_extras/nn/modules/extended_sequential.py
@@ -1,0 +1,49 @@
+import torch
+import copy
+
+
+class ExtendedSequential(torch.nn.Sequential):
+    """Sequential module with extended features from chainer.
+
+    """
+    def _copy_model(self, mode):
+        if mode == 'copy':
+            return copy.deepcopy(self)
+        else:
+            # mode == share
+            return copy.copy(self)
+
+    def repeat(self, n_repeat: int, mode: 'str' = 'copy'):
+        """Repeats this Sequential multiple times.
+
+        This method returns a :class:`~torch.nn.Sequential` object which has
+        original `Sequential` multiple times repeatedly. The ``mode``
+        argument means how to copy this sequential to repeat.
+
+        The functions is supposed to behave the same way as `repeat`
+        in `chainer`.
+
+        Args:
+            n_repeat (int): Number of times to repeat.
+            mode (str): It should be either ``copy``, or ``share``.
+                ``copy`` means that the parameters will not be re-initialized
+                but object itself will be deep-copied, so that all elements
+                have same initial parameters but can be changed independently.
+                ``share`` means all the elements which consist the resulting
+                :class:`~torch.nn.Sequential` object are same object because
+                they are shallow-copied, so that all parameters of elements
+                are shared with each other.
+                ``init`` is not supported yet.
+        """
+        if n_repeat <= 0:
+            return ExtendedSequential()
+
+        if mode not in ['copy', 'share']:
+            raise ValueError(
+                'The \'mode\' argument should be either ,'
+                '\'copy\', or \'share\'. But {} was given.'.format(mode))
+
+        model_list = []
+        for _ in range(n_repeat):
+            model_list.append(self._copy_model(mode))
+        return ExtendedSequential(*model_list)

--- a/pytorch_pfn_extras/nn/modules/extended_sequential.py
+++ b/pytorch_pfn_extras/nn/modules/extended_sequential.py
@@ -42,7 +42,10 @@ class ExtendedSequential(torch.nn.Sequential):
 
         Args:
             n_repeat (int): Number of times to repeat.
-            mode (str): It should be either ``copy``, or ``share``.
+            mode (str): It should be either ``init``, ``copy``, or ``share``.
+                ``init`` means parameters of each repeated element in the
+                returned :class:`~torch.nn.Sequential` will be re-initialized,
+                so that all elements have different initial parameters.
                 ``copy`` means that the parameters will not be re-initialized
                 but object itself will be deep-copied, so that all elements
                 have same initial parameters but can be changed independently.
@@ -50,14 +53,13 @@ class ExtendedSequential(torch.nn.Sequential):
                 :class:`~torch.nn.Sequential` object are same object because
                 they are shallow-copied, so that all parameters of elements
                 are shared with each other.
-                ``init`` is not supported yet.
         """
         if n_repeat <= 0:
             return ExtendedSequential()
 
         if mode not in ['copy', 'share', 'init']:
             raise ValueError(
-                'The \'mode\' argument should be either ,'
+                'The \'mode\' argument should be either \'init\','
                 '\'copy\', or \'share\'. But {} was given.'.format(mode))
 
         model_list = []

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
@@ -1,16 +1,135 @@
 import unittest
+import pytest
+
 import numpy
 from torch import nn
 import pytorch_pfn_extras as ppe
 
+assertions = unittest.TestCase('__init__')
 
-class TestExtendedSequential(unittest.TestCase):
+@pytest.mark.parametrize('module', [nn.Sequential,
+                                    nn.ModuleList])
+class TestExtendedSequential(object):
+
+    @pytest.fixture(autouse=True)
+    def setUp(self, module):
+        self.l1 = ppe.nn.LazyLinear(None, 3)
+        self.l2 = nn.Linear(3, 2)
+        self.l3 = nn.Linear(2, 3)
+        # s1: l1 -> l2
+        if module == nn.Sequential:
+            self.s1 = module(self.l1, self.l2)
+        elif module == nn.ModuleDict:
+            self.s1 = module({
+                'l1': self.l1,
+                'l2': self.l2})
+        else:
+            self.s1 = module([self.l1, self.l2])
+        # s2: s1 (l1 -> l2) -> l3
+        self.s2 = ppe.nn.ExtendedSequential(self.s1, self.l3)
+
+    def test_repeat_with_init(self):
+        # s2 ((l1 -> l2) -> l3) -> s2 ((l1 -> l2) -> l3)
+        ret = self.s2.repeat(2)
+        assertions.assertIsNot(ret[0], self.s2)
+        assertions.assertIs(type(ret[0]), type(self.s2))
+        assertions.assertIsNot(ret[1], self.s2)
+        assertions.assertIs(type(ret[1]), type(self.s2))
+
+        # bias is filled with 0, so they should have the same values
+        numpy.testing.assert_array_equal(
+            ret[0][0][0].bias.detach().numpy(),
+            ret[1][0][0].bias.detach().numpy())
+        # weight is initialized randomly, so they should be different
+        assertions.assertFalse(
+            numpy.array_equal(ret[0][1].weight.detach().numpy(),
+                              self.l3.weight.detach().numpy()))
+        # And the object should also be different
+        assertions.assertIsNot(ret[0][1].weight.detach().numpy(),
+                               self.l3.weight.detach().numpy())
+        # Repeated elements should be different objects
+        assertions.assertIsNot(ret[0], ret[1])
+        # Also for the arrays
+        assertions.assertIsNot(ret[0][1].weight.detach().numpy(),
+                               ret[1][1].weight.detach().numpy())
+        # And values should be different
+        assertions.assertFalse(
+            numpy.array_equal(ret[0][1].weight.detach().numpy(),
+                              ret[1][1].weight.detach().numpy()))
+
+        assertions.assertEqual(len(ret), 2)
+        ret = self.s2.repeat(0, mode='init')
+        assertions.assertEqual(len(ret), 0)
+
+    def test_repeat_with_copy(self):
+        # s2 ((l1 -> l2) -> l3) -> s2 ((l1 -> l2) -> l3)
+        ret = self.s2.repeat(2, mode='copy')
+        assertions.assertIsNot(ret[0], self.s2)
+        assertions.assertIs(type(ret[0]), type(self.s2))
+        assertions.assertIsNot(ret[1], self.s2)
+        assertions.assertIs(type(ret[1]), type(self.s2))
+        assertions.assertIsNot(ret[0], ret[1])
+
+        # b is filled with 0, so they should have the same values
+        numpy.testing.assert_array_equal(
+            ret[0][0][0].bias.detach().numpy(),
+            ret[1][0][0].bias.detach().numpy())
+        # W is shallowy copied, so the values should be same
+        numpy.testing.assert_array_equal(
+            ret[0][1].weight.detach().numpy(), self.l3.weight.detach().numpy())
+        # But the object should be different
+        assertions.assertIsNot(ret[0][1].weight, self.l3.weight)
+        # Repeated elements should be different objects
+        assertions.assertIsNot(ret[0][0], ret[1][0])
+        # Also for the arrays
+        assertions.assertIsNot(ret[0][1].weight, ret[1][1].weight)
+        # But the values should be same
+        numpy.testing.assert_array_equal(
+            ret[0][1].weight.detach().numpy(),
+            ret[1][1].weight.detach().numpy())
+
+        assertions.assertEqual(len(ret), 2)
+        ret = self.s2.repeat(0, mode='copy')
+        assertions.assertEqual(len(ret), 0)
+
+    def test_repeat_with_share(self):
+        # s2 ((l1 -> l2) -> l3) -> s2 ((l1 -> l2) -> l3)
+        ret = self.s2.repeat(2, mode='share')
+        assertions.assertIsNot(ret[0], self.s2)
+        assertions.assertIs(type(ret[0]), type(self.s2))
+        assertions.assertIsNot(ret[1], self.s2)
+        assertions.assertIs(type(ret[1]), type(self.s2))
+
+        # b is filled with 0, so they should have the same values
+        numpy.testing.assert_array_equal(
+            ret[0][0][0].bias.detach().numpy(),
+            ret[1][0][0].bias.detach().numpy())
+        # W is shallowy copied, so the values should be same
+        numpy.testing.assert_array_equal(
+            ret[0][1].weight.detach().numpy(), self.l3.weight.detach().numpy())
+        numpy.testing.assert_array_equal(
+            ret[1][1].weight.detach().numpy(), self.l3.weight.detach().numpy())
+        # And the object should also be same
+        assertions.assertIs(ret[0][1].weight, self.l3.weight)
+        assertions.assertIs(ret[1][1].weight, self.l3.weight)
+        # Repeated element itself should be different
+        assertions.assertIsNot(ret[0], ret[1])
+
+        assertions.assertEqual(len(ret), 2)
+        ret = self.s2.repeat(0, mode='share')
+        assertions.assertEqual(len(ret), 0)
+
+
+class TestExtendedSequentialModuleDict(unittest.TestCase):
+
     def setUp(self):
         self.l1 = ppe.nn.LazyLinear(None, 3)
         self.l2 = nn.Linear(3, 2)
         self.l3 = nn.Linear(2, 3)
         # s1: l1 -> l2
-        self.s1 = ppe.nn.ExtendedSequential(self.l1, self.l2)
+        self.s1 = nn.ModuleDict({
+                'l1': self.l1,
+                'l2': self.l2})
         # s2: s1 (l1 -> l2) -> l3
         self.s2 = ppe.nn.ExtendedSequential(self.s1, self.l3)
 
@@ -24,8 +143,8 @@ class TestExtendedSequential(unittest.TestCase):
 
         # bias is filled with 0, so they should have the same values
         numpy.testing.assert_array_equal(
-            ret[0][0][0].bias.detach().numpy(),
-            ret[1][0][0].bias.detach().numpy())
+            ret[0][0]['l1'].bias.detach().numpy(),
+            ret[1][0]['l1'].bias.detach().numpy())
         # weight is initialized randomly, so they should be different
         self.assertFalse(
             numpy.array_equal(ret[0][1].weight.detach().numpy(),
@@ -58,8 +177,8 @@ class TestExtendedSequential(unittest.TestCase):
 
         # b is filled with 0, so they should have the same values
         numpy.testing.assert_array_equal(
-            ret[0][0][0].bias.detach().numpy(),
-            ret[1][0][0].bias.detach().numpy())
+            ret[0][0]['l1'].bias.detach().numpy(),
+            ret[1][0]['l1'].bias.detach().numpy())
         # W is shallowy copied, so the values should be same
         numpy.testing.assert_array_equal(
             ret[0][1].weight.detach().numpy(), self.l3.weight.detach().numpy())
@@ -88,8 +207,8 @@ class TestExtendedSequential(unittest.TestCase):
 
         # b is filled with 0, so they should have the same values
         numpy.testing.assert_array_equal(
-            ret[0][0][0].bias.detach().numpy(),
-            ret[1][0][0].bias.detach().numpy())
+            ret[0][0]["l1"].bias.detach().numpy(),
+            ret[1][0]["l1"].bias.detach().numpy())
         # W is shallowy copied, so the values should be same
         numpy.testing.assert_array_equal(
             ret[0][1].weight.detach().numpy(), self.l3.weight.detach().numpy())

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
@@ -1,0 +1,73 @@
+import unittest
+import numpy
+from torch import nn
+import pytorch_pfn_extras as ppe
+
+
+class TestExtendedSequential(unittest.TestCase):
+    def setUp(self):
+        self.l1 = ppe.nn.LazyLinear(None, 3)
+        self.l2 = nn.Linear(3, 2)
+        self.l3 = nn.Linear(2, 3)
+        # s1: l1 -> l2
+        self.s1 = ppe.nn.ExtendedSequential(self.l1, self.l2)
+        # s2: s1 (l1 -> l2) -> l3
+        self.s2 = ppe.nn.ExtendedSequential(self.s1, self.l3)
+
+    def test_repeat_with_copy(self):
+        # s2 ((l1 -> l2) -> l3) -> s2 ((l1 -> l2) -> l3)
+        ret = self.s2.repeat(2, mode='copy')
+        self.assertIsNot(ret[0], self.s2)
+        self.assertIs(type(ret[0]), type(self.s2))
+        self.assertIsNot(ret[1], self.s2)
+        self.assertIs(type(ret[1]), type(self.s2))
+        self.assertIsNot(ret[0], ret[1])
+
+        # b is filled with 0, so they should have the same values
+        numpy.testing.assert_array_equal(
+            ret[0][0][0].bias.detach().numpy(),
+            ret[1][0][0].bias.detach().numpy())
+        # W is shallowy copied, so the values should be same
+        numpy.testing.assert_array_equal(
+            ret[0][1].weight.detach().numpy(), self.l3.weight.detach().numpy())
+        # But the object should be different
+        self.assertIsNot(ret[0][1].weight, self.l3.weight)
+        # Repeated elements should be different objects
+        self.assertIsNot(ret[0][0], ret[1][0])
+        # Also for the arrays
+        self.assertIsNot(ret[0][1].weight, ret[1][1].weight)
+        # But the values should be same
+        numpy.testing.assert_array_equal(
+            ret[0][1].weight.detach().numpy(),
+            ret[1][1].weight.detach().numpy())
+
+        self.assertEqual(len(ret), 2)
+        ret = self.s2.repeat(0, mode='copy')
+        self.assertEqual(len(ret), 0)
+
+    def test_repeat_with_share(self):
+        # s2 ((l1 -> l2) -> l3) -> s2 ((l1 -> l2) -> l3)
+        ret = self.s2.repeat(2, mode='share')
+        self.assertIsNot(ret[0], self.s2)
+        self.assertIs(type(ret[0]), type(self.s2))
+        self.assertIsNot(ret[1], self.s2)
+        self.assertIs(type(ret[1]), type(self.s2))
+
+        # b is filled with 0, so they should have the same values
+        numpy.testing.assert_array_equal(
+            ret[0][0][0].bias.detach().numpy(),
+            ret[1][0][0].bias.detach().numpy())
+        # W is shallowy copied, so the values should be same
+        numpy.testing.assert_array_equal(
+            ret[0][1].weight.detach().numpy(), self.l3.weight.detach().numpy())
+        numpy.testing.assert_array_equal(
+            ret[1][1].weight.detach().numpy(), self.l3.weight.detach().numpy())
+        # And the object should also be same
+        self.assertIs(ret[0][1].weight, self.l3.weight)
+        self.assertIs(ret[1][1].weight, self.l3.weight)
+        # Repeated element itself should be different
+        self.assertIsNot(ret[0], ret[1])
+
+        self.assertEqual(len(ret), 2)
+        ret = self.s2.repeat(0, mode='share')
+        self.assertEqual(len(ret), 0)

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
@@ -7,8 +7,10 @@ import pytorch_pfn_extras as ppe
 
 assertions = unittest.TestCase('__init__')
 
+
 @pytest.mark.parametrize('module', [nn.Sequential,
-                                    nn.ModuleList])
+                                    nn.ModuleList,
+                                    nn.ModuleDict])
 class TestExtendedSequential(object):
 
     @pytest.fixture(autouse=True)
@@ -25,6 +27,7 @@ class TestExtendedSequential(object):
                 'l2': self.l2})
         else:
             self.s1 = module([self.l1, self.l2])
+        self.module = module
         # s2: s1 (l1 -> l2) -> l3
         self.s2 = ppe.nn.ExtendedSequential(self.s1, self.l3)
 
@@ -37,9 +40,14 @@ class TestExtendedSequential(object):
         assertions.assertIs(type(ret[1]), type(self.s2))
 
         # bias is filled with 0, so they should have the same values
-        numpy.testing.assert_array_equal(
-            ret[0][0][0].bias.detach().numpy(),
-            ret[1][0][0].bias.detach().numpy())
+        if self.module == nn.ModuleDict:
+            numpy.testing.assert_array_equal(
+                ret[0][0]['l1'].bias.detach().numpy(),
+                ret[1][0]['l1'].bias.detach().numpy())
+        else:
+            numpy.testing.assert_array_equal(
+                ret[0][0][0].bias.detach().numpy(),
+                ret[1][0][0].bias.detach().numpy())
         # weight is initialized randomly, so they should be different
         assertions.assertFalse(
             numpy.array_equal(ret[0][1].weight.detach().numpy(),
@@ -71,9 +79,14 @@ class TestExtendedSequential(object):
         assertions.assertIsNot(ret[0], ret[1])
 
         # b is filled with 0, so they should have the same values
-        numpy.testing.assert_array_equal(
-            ret[0][0][0].bias.detach().numpy(),
-            ret[1][0][0].bias.detach().numpy())
+        if self.module == nn.ModuleDict:
+            numpy.testing.assert_array_equal(
+                ret[0][0]["l1"].bias.detach().numpy(),
+                ret[1][0]["l1"].bias.detach().numpy())
+        else:
+            numpy.testing.assert_array_equal(
+                ret[0][0][0].bias.detach().numpy(),
+                ret[1][0][0].bias.detach().numpy())
         # W is shallowy copied, so the values should be same
         numpy.testing.assert_array_equal(
             ret[0][1].weight.detach().numpy(), self.l3.weight.detach().numpy())
@@ -101,9 +114,14 @@ class TestExtendedSequential(object):
         assertions.assertIs(type(ret[1]), type(self.s2))
 
         # b is filled with 0, so they should have the same values
-        numpy.testing.assert_array_equal(
-            ret[0][0][0].bias.detach().numpy(),
-            ret[1][0][0].bias.detach().numpy())
+        if self.module == nn.ModuleDict:
+            numpy.testing.assert_array_equal(
+                ret[0][0]["l1"].bias.detach().numpy(),
+                ret[1][0]["l1"].bias.detach().numpy())
+        else:
+            numpy.testing.assert_array_equal(
+                ret[0][0][0].bias.detach().numpy(),
+                ret[1][0][0].bias.detach().numpy())
         # W is shallowy copied, so the values should be same
         numpy.testing.assert_array_equal(
             ret[0][1].weight.detach().numpy(), self.l3.weight.detach().numpy())
@@ -118,108 +136,3 @@ class TestExtendedSequential(object):
         assertions.assertEqual(len(ret), 2)
         ret = self.s2.repeat(0, mode='share')
         assertions.assertEqual(len(ret), 0)
-
-
-class TestExtendedSequentialModuleDict(unittest.TestCase):
-
-    def setUp(self):
-        self.l1 = ppe.nn.LazyLinear(None, 3)
-        self.l2 = nn.Linear(3, 2)
-        self.l3 = nn.Linear(2, 3)
-        # s1: l1 -> l2
-        self.s1 = nn.ModuleDict({
-                'l1': self.l1,
-                'l2': self.l2})
-        # s2: s1 (l1 -> l2) -> l3
-        self.s2 = ppe.nn.ExtendedSequential(self.s1, self.l3)
-
-    def test_repeat_with_init(self):
-        # s2 ((l1 -> l2) -> l3) -> s2 ((l1 -> l2) -> l3)
-        ret = self.s2.repeat(2)
-        self.assertIsNot(ret[0], self.s2)
-        self.assertIs(type(ret[0]), type(self.s2))
-        self.assertIsNot(ret[1], self.s2)
-        self.assertIs(type(ret[1]), type(self.s2))
-
-        # bias is filled with 0, so they should have the same values
-        numpy.testing.assert_array_equal(
-            ret[0][0]['l1'].bias.detach().numpy(),
-            ret[1][0]['l1'].bias.detach().numpy())
-        # weight is initialized randomly, so they should be different
-        self.assertFalse(
-            numpy.array_equal(ret[0][1].weight.detach().numpy(),
-                              self.l3.weight.detach().numpy()))
-        # And the object should also be different
-        self.assertIsNot(ret[0][1].weight.detach().numpy(),
-                         self.l3.weight.detach().numpy())
-        # Repeated elements should be different objects
-        self.assertIsNot(ret[0], ret[1])
-        # Also for the arrays
-        self.assertIsNot(ret[0][1].weight.detach().numpy(),
-                         ret[1][1].weight.detach().numpy())
-        # And values should be different
-        self.assertFalse(
-            numpy.array_equal(ret[0][1].weight.detach().numpy(),
-                              ret[1][1].weight.detach().numpy()))
-
-        self.assertEqual(len(ret), 2)
-        ret = self.s2.repeat(0, mode='init')
-        self.assertEqual(len(ret), 0)
-
-    def test_repeat_with_copy(self):
-        # s2 ((l1 -> l2) -> l3) -> s2 ((l1 -> l2) -> l3)
-        ret = self.s2.repeat(2, mode='copy')
-        self.assertIsNot(ret[0], self.s2)
-        self.assertIs(type(ret[0]), type(self.s2))
-        self.assertIsNot(ret[1], self.s2)
-        self.assertIs(type(ret[1]), type(self.s2))
-        self.assertIsNot(ret[0], ret[1])
-
-        # b is filled with 0, so they should have the same values
-        numpy.testing.assert_array_equal(
-            ret[0][0]['l1'].bias.detach().numpy(),
-            ret[1][0]['l1'].bias.detach().numpy())
-        # W is shallowy copied, so the values should be same
-        numpy.testing.assert_array_equal(
-            ret[0][1].weight.detach().numpy(), self.l3.weight.detach().numpy())
-        # But the object should be different
-        self.assertIsNot(ret[0][1].weight, self.l3.weight)
-        # Repeated elements should be different objects
-        self.assertIsNot(ret[0][0], ret[1][0])
-        # Also for the arrays
-        self.assertIsNot(ret[0][1].weight, ret[1][1].weight)
-        # But the values should be same
-        numpy.testing.assert_array_equal(
-            ret[0][1].weight.detach().numpy(),
-            ret[1][1].weight.detach().numpy())
-
-        self.assertEqual(len(ret), 2)
-        ret = self.s2.repeat(0, mode='copy')
-        self.assertEqual(len(ret), 0)
-
-    def test_repeat_with_share(self):
-        # s2 ((l1 -> l2) -> l3) -> s2 ((l1 -> l2) -> l3)
-        ret = self.s2.repeat(2, mode='share')
-        self.assertIsNot(ret[0], self.s2)
-        self.assertIs(type(ret[0]), type(self.s2))
-        self.assertIsNot(ret[1], self.s2)
-        self.assertIs(type(ret[1]), type(self.s2))
-
-        # b is filled with 0, so they should have the same values
-        numpy.testing.assert_array_equal(
-            ret[0][0]["l1"].bias.detach().numpy(),
-            ret[1][0]["l1"].bias.detach().numpy())
-        # W is shallowy copied, so the values should be same
-        numpy.testing.assert_array_equal(
-            ret[0][1].weight.detach().numpy(), self.l3.weight.detach().numpy())
-        numpy.testing.assert_array_equal(
-            ret[1][1].weight.detach().numpy(), self.l3.weight.detach().numpy())
-        # And the object should also be same
-        self.assertIs(ret[0][1].weight, self.l3.weight)
-        self.assertIs(ret[1][1].weight, self.l3.weight)
-        # Repeated element itself should be different
-        self.assertIsNot(ret[0], ret[1])
-
-        self.assertEqual(len(ret), 2)
-        ret = self.s2.repeat(0, mode='share')
-        self.assertEqual(len(ret), 0)


### PR DESCRIPTION
This PR add repeat functionality to torch.nn.sequential.
The repeat behaves the same way as the one in chainer.

The tests cases are copied from chainer and modified to pytorch.