### PR TITLE
Fix flake8 syntax warnings

### DIFF
--- a/pytorch_pfn_extras/training/extensions/evaluator.py
+++ b/pytorch_pfn_extras/training/extensions/evaluator.py
@@ -277,6 +277,7 @@ class IgniteEvaluator(Evaluator):
 
     def set_evaluator_handlers(self):
         from ignite.engine import Events
+
         # Register handlers to retrieve the Average metrics and report them
         @self.evaluator.on(Events.EPOCH_STARTED)
         def set_evaluation_started(engine):

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -411,6 +411,7 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
 
     def set_ignite_handlers(self):
         from ignite.engine import Events
+
         # Set a handler that sets the reporter scope on every iteration
         @self.engine.on(Events.ITERATION_STARTED)
         def set_reporter_on_iter(engine):
@@ -427,6 +428,7 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
             iters_per_epoch = len(engine.state.dataloader)
             self._prepare_for_training(start_iteration, iters_per_epoch)
             self.start_extensions()
+
             # Make all the next
             # handlers to be executed after user defined ones
             @self.engine.on(Events.ITERATION_COMPLETED)

--- a/tests/pytorch_pfn_extras_tests/test_reporter.py
+++ b/tests/pytorch_pfn_extras_tests/test_reporter.py
@@ -75,7 +75,7 @@ def test_add_observer():
     reporter.report({'x': 1}, observer)
 
     observation = reporter.observation
-    assert 'o/x'in observation
+    assert 'o/x' in observation
     assert observation['o/x'] == 1
     assert 'x'not in observation
 
@@ -93,7 +93,7 @@ def test_add_observers():
     observation = reporter.observation
     assert 'o1/x' in observation
     assert observation['o1/x'] == 1
-    assert 'o2/y'in observation
+    assert 'o2/y' in observation
     assert observation['o2/y'] == 2
     assert 'x' not in observation
     assert 'y' not in observation
@@ -106,7 +106,7 @@ def test_report_without_observer():
     reporter.report({'x': 1})
 
     observation = reporter.observation
-    assert 'x'in observation
+    assert 'x' in observation
     assert observation['x'] == 1
 
 


### PR DESCRIPTION
The new flake8 version detects now issues that weren't detected before.
Fix the code to avoid these errors.