### PR TITLE
Fix writing file in windows 

### DIFF
--- a/pytorch_pfn_extras/writing.py
+++ b/pytorch_pfn_extras/writing.py
@@ -208,7 +208,7 @@ class Writer:
         with self.fs.open(tmppath, 'wb') as f:
             # HDFS does not support overwrite
             savefun(target, f)
-            self.fs.rename(tmppath, dest)
+        self.fs.rename(tmppath, dest)
         if make_backup:
             self.fs.remove(bak)
 


### PR DESCRIPTION
Closes #11 

This error only happens in windows, the actual tests should detect it.
It was not reproducible in linux.