### PR TITLE
Report means in `IgniteEvaluator`

### DIFF
--- a/pytorch_pfn_extras/training/extensions/evaluator.py
+++ b/pytorch_pfn_extras/training/extensions/evaluator.py
@@ -277,8 +277,9 @@ class IgniteEvaluator(Evaluator):
 
     def set_evaluator_handlers(self):
         from ignite.engine import Events
+
         # Register handlers to retrieve the Average metrics and report them
-        @self.evaluator.on(Events.EPOCH_STARTED)
+        @self.evaluator.on(Events.ITERATION_STARTED)
         def set_evaluation_started(engine):
             self.observation = {}
             self.cm = reporting.report_scope(self.observation)
@@ -290,14 +291,17 @@ class IgniteEvaluator(Evaluator):
                 self.updater.current_position = engine.state.iteration
                 self.pbar.update()
 
+        @self.evaluator.on(Events.ITERATION_COMPLETED)
+        def report_iteration_metrics(engine):
+            self.summary.add(self.observation)
+            self.cm.__exit__(None, None, None)
+
         @self.evaluator.on(Events.EPOCH_COMPLETED)
         def set_evaluation_completed(engine):
             metrics = self.evaluator.state.metrics
             for metric in metrics:
                 reporting.report(
                     {'val/{}'.format(metric): metrics[metric]})
-            self.cm.__exit__(None, None, None)
-            self.summary.add(self.observation)
 
     def evaluate(self):
         iterator = self._iterators['main']


### PR DESCRIPTION
When using `IgniteEvaluator` with custom metrics instead of ignite provided ones, the value reported was the last one instead of the average of the values.

The reporting scope was not correctly set.