### PR TITLE
Bugfix extended sequential

### DIFF
--- a/pytorch_pfn_extras/nn/modules/extended_sequential.py
+++ b/pytorch_pfn_extras/nn/modules/extended_sequential.py
@@ -17,9 +17,7 @@ def _reset_parameters(model):
         elif hasattr(model, '_reset_parameters'):
             model._reset_parameters()
         else:
-            module_name = model.__module__
-            if not (module_name.startswith('torch.nn') or
-                    module_name.startswith('pytorch_pfn_extras.nn')):
+            if len(list(model.parameters())) != 0:
                 warnings.warn('Cannot reset the parameters of module {}. '
                               'Consider adding `reset_parameters` or'
                               '`_reset_parameters`'
@@ -52,7 +50,7 @@ class ExtendedSequential(torch.nn.Sequential):
         The functions is supposed to behave the same way as `repeat`
         in `chainer`.
 
-        For user-defined module, add a ``reset_parameters`` or
+        For user-defined module with parameters, add a ``reset_parameters`` or
         ``_reset_parameters`` function to repeat with mode ``init``.
         Otherwise, a warning message is generated.
 

--- a/pytorch_pfn_extras/nn/modules/extended_sequential.py
+++ b/pytorch_pfn_extras/nn/modules/extended_sequential.py
@@ -15,9 +15,6 @@ def _reset_parameters(model):
             model.reset_parameters()
         elif hasattr(model, '_reset_parameters'):
             model._reset_parameters()
-        else:
-            raise RuntimeError(
-                "Can not reset parameters of model {}".format(model))
     return model
 
 

--- a/pytorch_pfn_extras/nn/modules/extended_sequential.py
+++ b/pytorch_pfn_extras/nn/modules/extended_sequential.py
@@ -11,7 +11,8 @@ def _reset_parameters(model):
         for submodel in model.values():
             _reset_parameters(submodel)
     else:
-        if isinstance(model, torch.nn.Module):
+        if (isinstance(model, torch.nn.Module) and
+           hasattr(model, 'reset_parameters')):
             model.reset_parameters()
     return model
 

--- a/pytorch_pfn_extras/nn/modules/extended_sequential.py
+++ b/pytorch_pfn_extras/nn/modules/extended_sequential.py
@@ -11,9 +11,13 @@ def _reset_parameters(model):
         for submodel in model.values():
             _reset_parameters(submodel)
     else:
-        if (isinstance(model, torch.nn.Module) and
-           hasattr(model, 'reset_parameters')):
+        if hasattr(model, 'reset_parameters'):
             model.reset_parameters()
+        elif hasattr(model, '_reset_parameters'):
+            model._reset_parameters()
+        else:
+            raise RuntimeError(
+                "Can not reset parameters of model {}".format(model))
     return model
 
 

--- a/pytorch_pfn_extras/nn/modules/extended_sequential.py
+++ b/pytorch_pfn_extras/nn/modules/extended_sequential.py
@@ -52,6 +52,10 @@ class ExtendedSequential(torch.nn.Sequential):
         The functions is supposed to behave the same way as `repeat`
         in `chainer`.
 
+        For user-defined module, add a ``reset_parameters`` or
+        ``_reset_parameters`` function to repeat with mode ``init``.
+        Otherwise, a warning message is generated.
+
         Args:
             n_repeat (int): Number of times to repeat.
             mode (str): It should be either ``init``, ``copy``, or ``share``.

--- a/pytorch_pfn_extras/nn/modules/extended_sequential.py
+++ b/pytorch_pfn_extras/nn/modules/extended_sequential.py
@@ -20,8 +20,8 @@ def _reset_parameters(model):
             if (len(list(model.parameters())) != 0 or
                     len(list(model.buffers())) != 0):
                 warnings.warn('Cannot reset the parameters of module {}. '
-                              'Consider adding `reset_parameters` or'
-                              '`_reset_parameters`'
+                              'Consider adding `reset_parameters` or '
+                              '`_reset_parameters` '
                               'functions to the module'.format(model),
                               UserWarning)
 

--- a/pytorch_pfn_extras/nn/modules/extended_sequential.py
+++ b/pytorch_pfn_extras/nn/modules/extended_sequential.py
@@ -1,5 +1,6 @@
 import torch
 import copy
+import warnings
 
 
 def _reset_parameters(model):
@@ -15,6 +16,16 @@ def _reset_parameters(model):
             model.reset_parameters()
         elif hasattr(model, '_reset_parameters'):
             model._reset_parameters()
+        else:
+            module_name = model.__module__
+            if not (module_name.startswith('torch.nn') or
+                    module_name.startswith('pytorch_pfn_extras.nn')):
+                warnings.warn('Cannot reset the parameters of module {}. '
+                              'Consider adding `reset_parameters` or'
+                              '`_reset_parameters`'
+                              'functions to the module'.format(model),
+                              UserWarning)
+
     return model
 
 

--- a/pytorch_pfn_extras/nn/modules/extended_sequential.py
+++ b/pytorch_pfn_extras/nn/modules/extended_sequential.py
@@ -51,9 +51,17 @@ class ExtendedSequential(torch.nn.Sequential):
         The functions is supposed to behave the same way as `repeat`
         in `chainer`.
 
-        For user-defined module with parameters, add a ``reset_parameters`` or
-        ``_reset_parameters`` function to repeat with mode ``init``.
-        Otherwise, a warning message is generated.
+        When the mode is set to ``init``, the default value,
+        modules will be copied and reinitialized by calling
+        ``reset_parameters`` (or ``_reset_parameters``) method.
+
+        To repeat user-defined modules, which have parameters or buffers,
+        with mode=``init`` in this Sequential,
+        you need to implement the ``reset_parameters`` or ``_reset_parameters``
+        method to the module to reinitialize parameters
+        and (if necessary) buffers;
+        otherwise the initialization cannot be performed
+        and a warning message will be shown.
 
         Args:
             n_repeat (int): Number of times to repeat.

--- a/pytorch_pfn_extras/nn/modules/extended_sequential.py
+++ b/pytorch_pfn_extras/nn/modules/extended_sequential.py
@@ -17,7 +17,8 @@ def _reset_parameters(model):
         elif hasattr(model, '_reset_parameters'):
             model._reset_parameters()
         else:
-            if len(list(model.parameters())) != 0:
+            if (len(list(model.parameters())) != 0 or
+                    len(list(model.buffers())) != 0):
                 warnings.warn('Cannot reset the parameters of module {}. '
                               'Consider adding `reset_parameters` or'
                               '`_reset_parameters`'

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
@@ -18,6 +18,8 @@ class TestExtendedSequential(object):
         self.l1 = ppe.nn.LazyLinear(None, 3)
         self.l2 = nn.Linear(3, 2)
         self.l3 = nn.Linear(2, 3)
+        # a layer without reset_parameters
+        self.l4 = nn.ReLU()
         # s1: l1 -> l2
         if module == nn.Sequential:
             self.s1 = module(self.l1, self.l2)
@@ -28,11 +30,11 @@ class TestExtendedSequential(object):
         else:
             self.s1 = module([self.l1, self.l2])
         self.module = module
-        # s2: s1 (l1 -> l2) -> l3
-        self.s2 = ppe.nn.ExtendedSequential(self.s1, self.l3)
+        # s2: s1 (l1 -> l2) -> l3 -> l4
+        self.s2 = ppe.nn.ExtendedSequential(self.s1, self.l3, self.l4)
 
     def test_repeat_with_init(self):
-        # s2 ((l1 -> l2) -> l3) -> s2 ((l1 -> l2) -> l3)
+        # s2 ((l1 -> l2) -> l3 -> l4) -> s2 ((l1 -> l2) -> l3 -> l4)
         ret = self.s2.repeat(2)
         assertions.assertIsNot(ret[0], self.s2)
         assertions.assertIs(type(ret[0]), type(self.s2))
@@ -70,7 +72,7 @@ class TestExtendedSequential(object):
         assertions.assertEqual(len(ret), 0)
 
     def test_repeat_with_copy(self):
-        # s2 ((l1 -> l2) -> l3) -> s2 ((l1 -> l2) -> l3)
+        # s2 ((l1 -> l2) -> l3 -> l4) -> s2 ((l1 -> l2) -> l3 -> l4)
         ret = self.s2.repeat(2, mode='copy')
         assertions.assertIsNot(ret[0], self.s2)
         assertions.assertIs(type(ret[0]), type(self.s2))
@@ -106,7 +108,7 @@ class TestExtendedSequential(object):
         assertions.assertEqual(len(ret), 0)
 
     def test_repeat_with_share(self):
-        # s2 ((l1 -> l2) -> l3) -> s2 ((l1 -> l2) -> l3)
+        # s2 ((l1 -> l2) -> l3 -> l4) -> s2 ((l1 -> l2) -> l3 -> l4)
         ret = self.s2.repeat(2, mode='share')
         assertions.assertIsNot(ret[0], self.s2)
         assertions.assertIs(type(ret[0]), type(self.s2))

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
@@ -216,7 +216,7 @@ def test_no_warning_when_repeat(module):
 
 
 @pytest.mark.parametrize('module', [
-    UserDefinedLayerWithParameters
+    UserDefinedLayerWithParameters,
 ])
 def test_warning_when_repeat(module):
     model = ppe.nn.ExtendedSequential(module())

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
@@ -160,3 +160,43 @@ class TestExtendedSequential(object):
         assertions.assertEqual(len(ret), 2)
         ret = self.s2.repeat(0, mode='share')
         assertions.assertEqual(len(ret), 0)
+
+
+class UserDefinedLayerWithReset(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self):
+        pass
+
+    def reset_parameters(self):
+        pass
+
+
+class UserDefinedLayerWithUnderScoreReset(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self):
+        pass
+
+    def _reset_parameters(self):
+        pass
+
+
+@pytest.mark.parametrize('module', [nn.ReLU,
+                                    UserDefinedLayerWithUnderScoreReset,
+                                    UserDefinedLayerWithReset])
+def test_no_warning_when_repeat(module):
+    model = ppe.nn.ExtendedSequential(module())
+    # no warnings are raised on these modules
+    with pytest.warns(None):
+        model.repeat(2)
+
+
+@pytest.mark.parametrize('module', [UserDefinedLayer])
+def test_warning_when_repeat(module):
+    model = ppe.nn.ExtendedSequential(module())
+    # warnings are raised on these modules
+    with pytest.warns(UserWarning):
+        model.repeat(2)

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
@@ -9,10 +9,21 @@ import pytorch_pfn_extras as ppe
 assertions = unittest.TestCase('__init__')
 
 
+class UserDefinedLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self):
+        pass
+
+    def reset_parameters(self):
+        pass
+
 @pytest.mark.parametrize('module', [nn.Sequential,
                                     nn.ModuleList,
                                     nn.ModuleDict])
 @pytest.mark.parametrize('irregular_layer', [
+    UserDefinedLayer,
     # No reset_parameters
     nn.ReLU,
     # use reset_running_stats

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
@@ -198,6 +198,15 @@ class UserDefinedLayerWithParameters(nn.Module):
         pass
 
 
+class UserDefinedLayerWithBuffer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer('weight', torch.zeros(1, 1))
+
+    def forward(self):
+        pass
+
+
 @pytest.mark.parametrize('module', [
     # buit-in, no parameters
     nn.ReLU,
@@ -217,6 +226,7 @@ def test_no_warning_when_repeat(module):
 
 @pytest.mark.parametrize('module', [
     UserDefinedLayerWithParameters,
+    UserDefinedLayerWithBuffer,
 ])
 def test_warning_when_repeat(module):
     model = ppe.nn.ExtendedSequential(module())

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
@@ -16,8 +16,6 @@ class UserDefinedLayer(nn.Module):
     def forward(self):
         pass
 
-    def reset_parameters(self):
-        pass
 
 @pytest.mark.parametrize('module', [nn.Sequential,
                                     nn.ModuleList,


### PR DESCRIPTION
This PR fixes a bug when resetting layers. In pytorch,
there are layers with no parameters and therefore no `reset_parameters`,
such as `torch.nn.ReLU`. We need to skip such layers when resetting.

This closes #14 