### PR TITLE
[WIP] "Updater" as `process_function`s of ignite.Engine

### DIFF
--- a/example/ignite-mnist.py
+++ b/example/ignite-mnist.py
@@ -8,6 +8,7 @@ import torch.nn.functional as F
 from torchvision.transforms import Compose, ToTensor, Normalize
 from torchvision.datasets import MNIST
 
+from ignite.engine import Engine
 from ignite.engine import Events
 from ignite.engine import create_supervised_trainer
 from ignite.engine import create_supervised_evaluator
@@ -15,6 +16,7 @@ from ignite.metrics import Accuracy, Loss
 
 import pytorch_pfn_extras as ppe
 import pytorch_pfn_extras.training.extensions as extensions
+import pytorch_pfn_extras.training.updaters as updaters
 
 
 class Net(nn.Module):
@@ -61,8 +63,8 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
 
     optimizer = SGD(model.parameters(), lr=lr, momentum=momentum)
     optimizer.step()
-    trainer = create_supervised_trainer(
-        model, optimizer, F.nll_loss, device=device)
+    updater = updaters.SupervisedUpdater(model, optimizer, F.nll_loss, device=device)
+    trainer = Engine(updater)
     evaluator = create_supervised_evaluator(
         model,
         metrics={'acc': Accuracy(), 'loss': Loss(F.nll_loss)},

--- a/pytorch_pfn_extras/training/__init__.py
+++ b/pytorch_pfn_extras/training/__init__.py
@@ -6,3 +6,5 @@ from pytorch_pfn_extras.training.extension import PRIORITY_WRITER  # NOQA
 from pytorch_pfn_extras.training import extensions  # NOQA
 from pytorch_pfn_extras.training.manager import ExtensionsManager  # NOQA
 from pytorch_pfn_extras.training.manager import IgniteExtensionsManager  # NOQA
+from pytorch_pfn_extras.training.updater import Updater  # NOQA
+from pytorch_pfn_extras.training import updaters # NOQA

--- a/pytorch_pfn_extras/training/updater.py
+++ b/pytorch_pfn_extras/training/updater.py
@@ -1,0 +1,5 @@
+class Updater(object):
+
+    def __call__(self):
+        raise NotImplementedError(
+            'Updater implementation must override __call__')

--- a/pytorch_pfn_extras/training/updaters/__init__.py
+++ b/pytorch_pfn_extras/training/updaters/__init__.py
@@ -1,0 +1,2 @@
+from pytorch_pfn_extras.training.updaters.supervised_updater import SupervisedUpdater  # NOQA
+from pytorch_pfn_extras.training.updaters.mixed_fp16_updater import MixedFP16Updater  # NOQA

--- a/pytorch_pfn_extras/training/updaters/mixed_fp16_updater.py
+++ b/pytorch_pfn_extras/training/updaters/mixed_fp16_updater.py
@@ -1,0 +1,42 @@
+import warnings
+import ignite
+from pytorch_pfn_extras.training import Updater
+
+
+class MixedFP16Updater(Updater):
+    def __init__(self, model, optimizer, loss_fn,
+                 device=None, non_blocking=False,
+                 prepare_batch=ignite.engine._prepare_batch,
+                 output_transform=lambda x, y, y_pred, loss: loss.item()):
+        self.model = model
+        self.optimizer = optimizer
+        self.loss_fn = loss_fn
+        self.device = device
+        self.non_blocking = non_blocking
+        self.output_transform = output_transform
+        self.prepare_batch = prepare_batch
+
+        if self.device:
+            self.model.to(self.device)
+
+        try:
+            import apex
+            self.apex_available = True
+        except:
+            warnings.warn("Need apex for MixedFP16 training but failed to import")
+            self.apex_available = False
+
+    def __call__(self, engine, batch):
+        self.model.train()
+        self.optimizer.zero_grad()
+        x, y = self.prepare_batch(batch, device=self.device, non_blocking=self.non_blocking)
+        y_pred = self.model(x)
+        loss = self.loss_fn(y_pred, y)
+        if self.apex_available:
+            with apex.amp.scale_loss(loss, optimizer) as scaled_loss:
+                scaled_loss.backward()
+        else:
+            loss.backward()
+
+        self.optimizer.step()
+        return self.output_transform(x, y, y_pred, loss)

--- a/pytorch_pfn_extras/training/updaters/supervised_updater.py
+++ b/pytorch_pfn_extras/training/updaters/supervised_updater.py
@@ -1,0 +1,30 @@
+import ignite
+from pytorch_pfn_extras.training import Updater
+
+
+class SupervisedUpdater(Updater):
+    def __init__(self, model, optimizer, loss_fn,
+                 device=None, non_blocking=False,
+                 prepare_batch=ignite.engine._prepare_batch,
+                 output_transform=lambda x, y, y_pred, loss: loss.item()):
+        self.model = model
+        self.optimizer = optimizer
+        self.loss_fn = loss_fn
+        self.device = device
+        self.non_blocking = non_blocking
+        self.output_transform = output_transform
+        self.prepare_batch = prepare_batch
+
+        if self.device:
+            self.model.to(self.device)
+
+    def __call__(self, engine, batch):
+        self.model.train()
+        self.optimizer.zero_grad()
+        x, y = self.prepare_batch(batch, device=self.device, non_blocking=self.non_blocking)
+        y_pred = self.model(x)
+        loss = self.loss_fn(y_pred, y)
+        loss.backward()
+
+        self.optimizer.step()
+        return self.output_transform(x, y, y_pred, loss)


### PR DESCRIPTION
## Background

`ignite.Engine` accepts an arbitrary callable object as `process_function`, and the very useful frontend `create_supervised_classifier` sets it by a naive and fundamental one.
https://github.com/pytorch/ignite/blob/v0.3.0/ignite/engine/__init__.py#L16-L55

In my specific case where I wanted to train a model with FP16 Mixed Precision training using Apex, we need to inject the following step in the training loop.
```
-    loss.backward()
+    with amp.scale_loss(loss, optimizer) as scaled_loss:
+        scaled_loss.backward()
```
https://nvidia.github.io/apex/amp.html#opt-levels-and-properties

If we are using ignite trainer (Engine), since `create_supervised_classifier` is not made to be pluggable, we need to reimplement everything done inside it, just for the above patch.
The key motivation for this PR is to provide a reusable utility so that user don't have to code the whole 1 iteration just for the loss scaling stuff.

In order for this, in this PR I propose to introduce the `Updater` mechanism.
An Updater is supposed to be passed to ignite.Engine and called once for each iteration, and is in charge of 1-iteration training.
The `SupervisedUpdater` is the most naive one and is identical to ignite's `_update` in `create_supervised_classifier`. Also, `MixedFP16Updater` is the variant of the SupervisedUpdater with Apex loss-scaling support.
In addition to these predefined ones, there are some tasks that require differently structured update process such as GANs or triplets. I guess we can provide some of common ones, say, like "AdversarialUpdater", as common re-usable Updaters if they can be well generalized.
For now an `Updater` is nothing but a Callable with no additional attributes or methods.

I am actually not sure if this design in this PR is the best way, so if you have any suggestions I'm quite open to it.

## Other design options

### Providing `create_supervised_classifier`-like methods.

The `Updater` mechanism might be overkill for my specific case (of mixed fp16). As an alternative way, it is possible to provide something like a `create_supervised_mixed_fp16_trainer`.

### Simply recommend to write custom training loop

It is also possible to just ask users to write training/update process by themselves for any kind of custom update logic.

## Concerns

### Confusing name "Updater" for Chainer users

If we name the mechanism "Updater", since its responsibility is slightly different from Chainer's Updater (e.g. Epoch management), it may lead a confusion for those who are very familiar with Chainer.
\# If we don't think about Chainer, the name "Updater" sounds the best word choice to me, considering what it actually does (and how it is called in Ignite).


### PyTorch native mixed-precision support

The original motivation of this PR comes from use of Apex for mixed-fp16, but I noticed that the upcoming PyTorch 1.6 is going to introduce the native automatic mixed precision training support.
I have to check how it works and check if the Updater mechanism is still helpful.
https://pytorch.org/docs/master/notes/amp_examples.html

## TODOs
- [ ] Testing
- [ ] Docstrings