### PR TITLE
Remove `FoolUpdater` and do everything through the manager

### DIFF
--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -114,7 +114,7 @@ n_retains=-1, autoload=False)
         filename (str): Name of the file into which the object is serialized.
             It can be a format string, where the manager object is passed to
             the :meth:`str.format` method. For example,
-            ``'snapshot_{.updater.iteration}'`` is converted to
+            ``'snapshot_{.iteration}'`` is converted to
             ``'snapshot_10000'`` at the 10,000th iteration.
         savefun: Function to save the object. It takes two arguments: the
             output file path and the object to serialize.
@@ -162,7 +162,7 @@ n_retains=-1, autoload=False)
 
 
 def snapshot(savefun=None,
-             filename='snapshot_iter_{.updater.iteration}',
+             filename='snapshot_iter_{.iteration}',
              *,
              target=None,
              condition=None,
@@ -319,7 +319,7 @@ class _Snapshot(extension.Extension):
 
     def __init__(
             self, target=None, condition=None, writer=None,
-            filename='snapshot_iter_{.updater.iteration}',
+            filename='snapshot_iter_{.iteration}',
             snapshot_on_error=False, n_retains=-1, autoload=False,
             savefun=None,
             transform_models=None, autoload_transform_models=None):
@@ -445,7 +445,7 @@ class _DistributedSnapshot(_Snapshot):
 
     def __init__(
             self, target=None, condition=None, writer=None,
-            filename='snapshot_iter_{.updater.iteration}',
+            filename='snapshot_iter_{.iteration}',
             snapshot_on_error=False, n_retains=-1, autoload=False,
             saver_rank=0, savefun=None, transform_models=None,
             autoload_transform_models=None):

--- a/pytorch_pfn_extras/training/extensions/evaluator.py
+++ b/pytorch_pfn_extras/training/extensions/evaluator.py
@@ -243,7 +243,7 @@ class _IteratorProgressBar(util.ProgressBar):
 
         super().__init__(out=out)
 
-    def get_lines(self, manager):
+    def get_lines(self):
         iteration = self._iterator.current_position
         epoch_detail = self._iterator.epoch_detail
         epoch_size = getattr(self._iterator, '_epoch_size', None)

--- a/pytorch_pfn_extras/training/extensions/evaluator.py
+++ b/pytorch_pfn_extras/training/extensions/evaluator.py
@@ -170,13 +170,13 @@ class Evaluator(extension.Extension):
 
         summary = reporting.DictSummary()
 
-        updater = IterationStatus(len(iterator))
+        progress = IterationStatus(len(iterator))
         if self._progress_bar:
-            pbar = _IteratorProgressBar(iterator=updater)
+            pbar = _IteratorProgressBar(iterator=progress)
 
         with _in_eval_mode(self._targets.values()):
             for idx, batch in enumerate(iterator):
-                updater.current_position = idx
+                progress.current_position = idx
                 observation = {}
                 with reporting.report_scope(observation):
                     if isinstance(batch, (tuple, list)):
@@ -288,7 +288,7 @@ class IgniteEvaluator(Evaluator):
         if self._progress_bar:
             @self.evaluator.on(Events.ITERATION_STARTED)
             def update_progress_bar(engine):
-                self.updater.current_position = engine.state.iteration
+                self.progress.current_position = engine.state.iteration
                 self.pbar.update()
 
         @self.evaluator.on(Events.ITERATION_COMPLETED)
@@ -309,9 +309,9 @@ class IgniteEvaluator(Evaluator):
     def evaluate(self):
         iterator = self._iterators['main']
         self.summary = reporting.DictSummary()
-        self.updater = IterationStatus(len(iterator))
+        self.progress = IterationStatus(len(iterator))
         if self._progress_bar:
-            self.pbar = _IteratorProgressBar(iterator=self.updater)
+            self.pbar = _IteratorProgressBar(iterator=self.progress)
         self.evaluator.run(iterator)
         if self._progress_bar:
             self.pbar.close()

--- a/pytorch_pfn_extras/training/extensions/log_report.py
+++ b/pytorch_pfn_extras/training/extensions/log_report.py
@@ -83,7 +83,6 @@ keys=None, trigger=(1, 'epoch'), postprocess=None, filename='log', writer=None)
         # accumulate the observations
         keys = self._keys
         observation = manager.observation
-        updater = manager.updater
         summary = self._summary
 
         if keys is None:
@@ -100,8 +99,8 @@ keys=None, trigger=(1, 'epoch'), postprocess=None, filename='log', writer=None)
             for name, value in stats.items():
                 stats_cpu[name] = float(value)  # copy to CPU
 
-            stats_cpu['epoch'] = updater.epoch
-            stats_cpu['iteration'] = updater.iteration
+            stats_cpu['epoch'] = manager.epoch
+            stats_cpu['iteration'] = manager.iteration
             stats_cpu['elapsed_time'] = manager.elapsed_time
 
             if self._postprocess is not None:

--- a/pytorch_pfn_extras/training/extensions/plot_report.py
+++ b/pytorch_pfn_extras/training/extensions/plot_report.py
@@ -165,9 +165,8 @@ filename='plot.png', marker='x', grid=True)
             for name, value in stats.items():
                 stats_cpu[name] = float(value)  # copy to CPU
 
-            updater = manager.updater
-            stats_cpu['epoch'] = updater.epoch
-            stats_cpu['iteration'] = updater.iteration
+            stats_cpu['epoch'] = manager.epoch
+            stats_cpu['iteration'] = manager.iteration
             x = stats_cpu[self._x_key]
             data = self._data
 

--- a/pytorch_pfn_extras/training/extensions/progress_bar.py
+++ b/pytorch_pfn_extras/training/extensions/progress_bar.py
@@ -41,7 +41,7 @@ class ProgressBar(extension.Extension):
         iteration = manager.iteration
         # print the progress bar
         if iteration % self._update_interval == 0:
-            self._pbar.update(manager)
+            self._pbar.update()
 
     def finalize(self):
         self._pbar.close()

--- a/pytorch_pfn_extras/training/extensions/progress_bar.py
+++ b/pytorch_pfn_extras/training/extensions/progress_bar.py
@@ -7,7 +7,7 @@ from pytorch_pfn_extras.training.extensions import util
 
 class ProgressBar(extension.Extension):
 
-    """An extension to print a progress bar and recent training updater.
+    """An extension to print a progress bar and recent training status.
 
     This extension prints a progress bar at every call. It watches the current
     iteration and epoch to print the bar.
@@ -35,7 +35,10 @@ class ProgressBar(extension.Extension):
             self._training_length, self._bar_length, self._out)
 
     def __call__(self, manager):
-        iteration = manager.updater.iteration
+        if self._pbar.manager is None:
+            self._pbar.manager = manager
+
+        iteration = manager.iteration
         # print the progress bar
         if iteration % self._update_interval == 0:
             self._pbar.update(manager)
@@ -50,17 +53,18 @@ class _ManagerProgressBar(util.ProgressBar):
         super().__init__(out)
         self.training_length = training_length
         self.bar_length = bar_length
-        self.updater_template = None
+        self.progress_template = None
+        self.manager = None
 
-    def get_lines(self, manager):
-        assert manager is not None
+    def get_lines(self):
+        assert self.manager is not None
         lines = []
 
-        iteration = manager.updater.iteration
-        epoch = manager.updater.epoch_detail
+        iteration = self.manager.iteration
+        epoch = self.manager.epoch_detail
 
         if self.training_length is None:
-            t = manager._stop_trigger
+            t = self.manager._stop_trigger
             self.training_length = t.get_training_length()
         length, unit = self.training_length
 
@@ -80,12 +84,12 @@ class _ManagerProgressBar(util.ProgressBar):
         lines.append('this epoch [{}{}] {:6.2%}\n'.format(
             marks, '.' * (bar_length - len(marks)), epoch_rate))
 
-        if self.updater_template is None:
-            self.updater_template = (
+        if self.progress_template is None:
+            self.progress_template = (
                 '{0.iteration:10} iter, {0.epoch} epoch / %s %ss\n' %
                 self.training_length)
-        updater = self.updater_template.format(manager.updater)
-        lines.append(updater)
+        progress = self.progress_template.format(self.manager)
+        lines.append(progress)
 
         speed_t, speed_e = self.update_speed(iteration, epoch)
         if unit == 'iteration':

--- a/pytorch_pfn_extras/training/extensions/util.py
+++ b/pytorch_pfn_extras/training/extensions/util.py
@@ -83,7 +83,7 @@ class ProgressBar:
     def update(self, manager=None):
         self.erase_console()
 
-        lines = self.get_lines(manager)
+        lines = self.get_lines()
         for line in lines:
             self._out.write(line)
 

--- a/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
+++ b/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
@@ -288,7 +288,7 @@ grid=True)
                         numpy.atleast_1d(stat_dict['percentile']))
                 stats[i] = numpy.concatenate(stat_list, axis=0)
 
-        self._samples.add(stats, idx=manager.updater.iteration)
+        self._samples.add(stats, idx=manager.iteration)
 
         if self._trigger(manager):
             self.save_plot_using_module(plt, manager)

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -23,21 +23,6 @@ except AttributeError:
         _get_time = time.time
 
 
-class FoolUpdater:
-
-    def __init__(self, start_iteration, iters_per_epoch):
-        self.iteration = start_iteration
-        self._iters_per_epoch = iters_per_epoch
-
-    @property
-    def epoch(self):
-        return self.iteration // self._iters_per_epoch
-
-    @property
-    def epoch_detail(self):
-        return self.iteration / self._iters_per_epoch
-
-
 class _ExtensionEntry:
 
     def __init__(self, extension, priority, trigger, call_before_training):
@@ -65,11 +50,6 @@ class _BaseExtensionsManager:
     """
     Keeps track of the extensions and the current status
     """
-    # The updater is used for compatibility with old extensions
-    # written for Chainer.
-    # New extensions can access the current epoch and iteration
-    # directly from the manager.
-    updater = None
 
     def __init__(
             self,
@@ -130,16 +110,16 @@ class _BaseExtensionsManager:
         return _get_time()-self._start_time
 
     @property
-    def iteration(self):
-        return self.updater.iteration
+    def is_before_training(self):
+        return self.iteration == 0
 
     @property
     def epoch(self):
-        return self.updater.epoch
+        return self.iteration // self._iters_per_epoch
 
     @property
-    def is_before_training(self):
-        return self.updater is None or self.updater.iteration == 0
+    def epoch_detail(self):
+        return self.iteration / self._iters_per_epoch
 
     @property
     def stop_trigger(self):
@@ -155,8 +135,8 @@ class _BaseExtensionsManager:
             return self._out
 
     def _prepare_for_training(self, start_iteration, iters_per_epoch):
-        assert self.updater is None
-        self.updater = FoolUpdater(start_iteration, iters_per_epoch)
+        self.iteration = start_iteration
+        self._iters_per_epoch = iters_per_epoch
 
     def start_extensions(self):
         exts = self._extensions
@@ -292,10 +272,7 @@ class _BaseExtensionsManager:
         state_dict(transform_models=lambda n, x: x.module)
         """
         to_save = {}
-        if self.updater is not None:
-            to_save['_start_iteration'] = self.updater.iteration
-        else:
-            to_save['_start_iteration'] = 0
+        to_save['_start_iteration'] = self.iteration
         # Save manager status ?
         to_save['models'] = {
             name: transform_models(name, self._models[name]).state_dict()
@@ -317,8 +294,7 @@ class _BaseExtensionsManager:
             state, transform_models=lambda n, x: torch.nn.DataParallel(x))
         """
         self._start_iteration = to_load['_start_iteration']
-        if self.updater is not None:
-            self.updater.iteration = self._start_iteration
+        self.iteration = self._start_iteration
         for name in self._models:
             # TODO(ecastill) map_loc when loading the model and DDP check
             self._models[name].load_state_dict(to_load['models'][name])
@@ -373,7 +349,6 @@ class ExtensionsManager(_BaseExtensionsManager):
 
     @contextlib.contextmanager
     def run_iteration(self):
-        assert self.updater is not None
         if self._start_time is None:
             self._start_time = _get_time()
             self.start_extensions()
@@ -386,7 +361,7 @@ class ExtensionsManager(_BaseExtensionsManager):
                 # In chainer, the iteration count was increased
                 # just before calling the extensions, we need
                 # to keep the semantics
-                self.updater.iteration += 1
+                self.iteration += 1
                 self.run_extensions()
 
         if self._internal_stop_trigger(self):
@@ -453,7 +428,7 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
             # handlers to be executed after user defined ones
             @self.engine.on(Events.ITERATION_COMPLETED)
             def run_extensions_on_iter(engine):
-                self.updater.iteration = engine.state.iteration
+                self.iteration = engine.state.iteration
                 self.run_extensions()
 
             # This should be the last extension to be run

--- a/pytorch_pfn_extras/training/triggers/early_stopping_trigger.py
+++ b/pytorch_pfn_extras/training/triggers/early_stopping_trigger.py
@@ -138,7 +138,7 @@ class EarlyStoppingTrigger:
 
         if self._stop_condition():
             if self.verbose:
-                print('Epoch {}: early stopping'.format(manager.updater.epoch))
+                print('Epoch {}: early stopping'.format(manager.epoch))
             return True
 
         return False

--- a/pytorch_pfn_extras/training/triggers/interval_trigger.py
+++ b/pytorch_pfn_extras/training/triggers/interval_trigger.py
@@ -7,7 +7,7 @@ class IntervalTrigger:
     the number of updates, while `epoch` means the number of sweeps over the
     training dataset. Fractional values are allowed if the interval is a
     number of epochs; the trigger uses the `iteration` and `epoch_detail`
-    attributes defined by the updater.
+    attributes defined by the manager.
 
     For the description of triggers see
     :func:`~pytorch_pfn_extras.get_trigger`.
@@ -40,7 +40,7 @@ class IntervalTrigger:
         Args:
             manager (~pytorch_pfn_extras.training.ExtensionsManager):
                 Manager object that this trigger is associated with.
-                The updater associated with this manager is used to
+                The iteration related information in this manager is used to
                 determine if the trigger should fire.
 
         Returns:
@@ -48,15 +48,14 @@ class IntervalTrigger:
             iteration.
 
         """
-        updater = manager.updater
         if self.unit == 'epoch':
-            epoch_detail = updater.epoch_detail
+            epoch_detail = manager.epoch_detail
             previous_epoch_detail = self._previous_epoch_detail
 
             # if previous_epoch_detail is invalid value,
-            # use the value of updater.
+            # use the value of manager.
             if previous_epoch_detail < 0:
-                previous_epoch_detail = updater.previous_epoch_detail
+                previous_epoch_detail = manager.previous_epoch_detail
 
             # count is kept for backward compatibility
             self.count = epoch_detail // self.period
@@ -64,7 +63,7 @@ class IntervalTrigger:
             fire = previous_epoch_detail // self.period != \
                 epoch_detail // self.period
         else:
-            iteration = updater.iteration
+            iteration = manager.iteration
             previous_iteration = self._previous_iteration
 
             # if previous_iteration is invalid value,
@@ -76,9 +75,9 @@ class IntervalTrigger:
                 iteration // self.period
 
         # save current values
-        self._previous_iteration = updater.iteration
-        if hasattr(updater, 'epoch_detail'):
-            self._previous_epoch_detail = updater.epoch_detail
+        self._previous_iteration = manager.iteration
+        if hasattr(manager, 'epoch_detail'):
+            self._previous_epoch_detail = manager.epoch_detail
 
         return fire
 

--- a/pytorch_pfn_extras/training/triggers/manual_schedule_trigger.py
+++ b/pytorch_pfn_extras/training/triggers/manual_schedule_trigger.py
@@ -7,7 +7,7 @@ class ManualScheduleTrigger:
     ``iteration`` means the number of updates, while ``epoch`` means the number
     of sweeps over the training dataset. Fractional values are allowed
     if the point is a number of epochs; the trigger uses the ``iteration``
-    and ``epoch_detail`` attributes defined by the updater.
+    and ``epoch_detail`` attributes defined by the manager.
 
     Args:
         points (int, float, or list of int or float): time of the trigger.
@@ -40,7 +40,7 @@ class ManualScheduleTrigger:
         Args:
             manager (~pytorch_pfn_extras.training.ExtensionsManager):
                 Manager object that this trigger is associated with.
-                The updater associated with this manager is used to
+                The iteration information in this manager is used to
                 determine if the trigger should fire.
 
         Returns:
@@ -48,15 +48,14 @@ class ManualScheduleTrigger:
             iteration.
 
         """
-        updater = manager.updater
         if self.unit == 'epoch':
-            epoch_detail = updater.epoch_detail
+            epoch_detail = manager.epoch_detail
             previous_epoch_detail = self._previous_epoch_detail
 
             # if previous_epoch_detail is invalid value,
-            # use the value of updater.
+            # use the value of manager.
             if previous_epoch_detail < 0:
-                previous_epoch_detail = updater.previous_epoch_detail
+                previous_epoch_detail = manager.previous_epoch_detail
 
             fire = any(
                 previous_epoch_detail < p <= epoch_detail
@@ -69,7 +68,7 @@ class ManualScheduleTrigger:
             if fire and epoch_detail >= max(self.points):
                 self.finished = True
         else:
-            iteration = updater.iteration
+            iteration = manager.iteration
             previous_iteration = self._previous_iteration
 
             # if previous_iteration is invalid value,
@@ -89,9 +88,9 @@ class ManualScheduleTrigger:
                 self.finished = True
 
         # save current values
-        self._previous_iteration = updater.iteration
-        if hasattr(updater, 'epoch_detail'):
-            self._previous_epoch_detail = updater.epoch_detail
+        self._previous_iteration = manager.iteration
+        if hasattr(manager, 'epoch_detail'):
+            self._previous_epoch_detail = manager.epoch_detail
 
         return fire
 

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_progress_bar.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_progress_bar.py
@@ -21,8 +21,8 @@ def test_run():
     for epoch in range(max_epochs):
         for batch_idx in range(iters_per_epoch):
             with manager.run_iteration():
-                if manager.updater.iteration < 2:
+                if manager.iteration < 2:
                     continue
                 status = '{} iter, {} epoch / {} epochs'.format(
-                    manager.updater.iteration, epoch, max_epochs)
+                    manager.iteration, epoch, max_epochs)
                 assert status in out.getvalue()

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
@@ -352,7 +352,7 @@ def test_model_transformations(path):
 
     # Verify that autoload applies the transformation
     to_load = torch.load(os.path.join(path, 'test'))
-    trainer = get_trainer_with_mock_updater(
+    trainer = get_trainer(
         out_dir=path, state_to_load=to_load)
     snapshot = extensions.snapshot(
         filename='test', autoload=True,

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
@@ -16,7 +16,7 @@ from pytorch_pfn_extras.training.extensions._snapshot import (
 from pytorch_pfn_extras import writing
 
 
-def get_trainer_with_mock_updater(*, out_dir, state_to_load=None):
+def get_trainer(*, out_dir, state_to_load=None):
     model_state_dict = {}
     optimizer_state_dict = {}
     models = {'main': _StateDictModel(state_dict=model_state_dict)}
@@ -81,7 +81,7 @@ def remover():
 
 
 def test_save_file(remover):
-    trainer = get_trainer_with_mock_updater(out_dir='.')
+    trainer = get_trainer(out_dir='.')
     trainer._done = True
     w = writing.SimpleWriter()
     snapshot = extensions.snapshot_object(trainer, 'myfile.dat',
@@ -92,7 +92,7 @@ def test_save_file(remover):
 
 
 def test_multi_target(remover):
-    trainer = get_trainer_with_mock_updater(out_dir='.')
+    trainer = get_trainer(out_dir='.')
     trainer._done = True
     other_state_dict = {'test': True}
     other = _StateDictObj(state_dict=other_state_dict)
@@ -105,7 +105,7 @@ def test_multi_target(remover):
     assert os.path.exists('myfile.dat')
     # Load the snapshot and verify it
     state = torch.load('myfile.dat')
-    new_trainer = get_trainer_with_mock_updater(out_dir='.')
+    new_trainer = get_trainer(out_dir='.')
     new_other = _StateDictObj(state_dict={})
     new_trainer.load_state_dict(state['trainer'])
     new_other.load_state_dict(state['other'])
@@ -114,7 +114,7 @@ def test_multi_target(remover):
 
 
 def test_multi_target_autoload(remover):
-    trainer = get_trainer_with_mock_updater(out_dir='.')
+    trainer = get_trainer(out_dir='.')
     trainer._done = True
     other_state_dict = {'test': True}
     other = _StateDictObj(state_dict=other_state_dict)
@@ -125,7 +125,7 @@ def test_multi_target_autoload(remover):
     snapshot(trainer)
 
     assert os.path.exists('myfile.dat')
-    new_trainer = get_trainer_with_mock_updater(out_dir='.')
+    new_trainer = get_trainer(out_dir='.')
     new_other = _StateDictObj(state_dict={})
 
     target = {'trainer': new_trainer, 'other': new_other}
@@ -138,7 +138,7 @@ def test_multi_target_autoload(remover):
 
 
 def test_clean_up_tempdir(remover):
-    trainer = get_trainer_with_mock_updater(out_dir='.')
+    trainer = get_trainer(out_dir='.')
     trainer._done = True
     snapshot = extensions.snapshot_object(trainer, 'myfile.dat')
     snapshot(trainer)
@@ -277,12 +277,12 @@ def test_find_stale_snapshot(length_retain, path):
 
 
 def test_remove_stale_snapshots(path):
-    fmt = 'snapshot_iter_{.updater.iteration}'
+    fmt = 'snapshot_iter_{.iteration}'
     retain = 3
     snapshot = extensions.snapshot(filename=fmt, n_retains=retain,
                                    autoload=False)
 
-    trainer = get_trainer_with_mock_updater(out_dir=path)
+    trainer = get_trainer(out_dir=path)
     trainer.extend(snapshot, trigger=(1, 'iteration'), priority=2)
 
     class TimeStampUpdater():
@@ -311,7 +311,7 @@ def test_remove_stale_snapshots(path):
     expected.sort()
     assert expected == found
 
-    trainer2 = get_trainer_with_mock_updater(
+    trainer2 = get_trainer(
         out_dir=path, state_to_load=trainer.state_dict())
     snapshot2 = extensions.snapshot(filename=fmt, autoload=True)
     # Just making sure no error occurs

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
@@ -6,15 +6,21 @@ from torch import nn
 from pytorch_pfn_extras import training
 
 
-def test_fool_updater():
-    updater = training.manager.FoolUpdater(9, 4)
-    assert updater.iteration == 9
-    assert updater.epoch == 2
-    assert updater.epoch_detail == 2.25
+def test_manager_status_info():
+    manager = training.ExtensionsManager(
+        nn.Module(),
+        object(),
+        10,
+        iters_per_epoch=4
+    )
+    manager.iteration = 9
+    assert manager.iteration == 9
+    assert manager.epoch == 2
+    assert manager.epoch_detail == 2.25
 
-    updater.iteration = 15
-    assert updater.epoch == 3
-    assert updater.epoch_detail == 3.75
+    manager.iteration = 15
+    assert manager.epoch == 3
+    assert manager.epoch_detail == 3.75
 
 
 class _DummyExtension(object):
@@ -77,7 +83,7 @@ def test_extensions_manager_extensions():
         init_record.clear()
 
         with manager.run_iteration():
-            assert manager.updater.iteration == it
+            assert manager.iteration == it
 
             if it == 0:
                 assert call_record == [4, 0, 3]

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_trigger_util.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_trigger_util.py
@@ -22,7 +22,7 @@ from pytorch_pfn_extras.training import triggers
          [False, False, False, False, False, False, False]),
         (2, triggers.IntervalTrigger(2, 'iteration'),
          [False, True, False, True, False, True, False]),
-        (2, (lambda trainer: trainer.updater.iteration == 3),
+        (2, (lambda trainer: trainer.iteration == 3),
          [False, False, True, False, False, False, False]),
     ]
 )


### PR DESCRIPTION
The `updater` attribute of the manager was introduced to simplify adapting some components to PyTorch. However,  since there is no real Updater in ppe, it shouldn't be relied upon.

This change might break some user code when they use their old chainer extensions with ppe but I think is a good moment to get rid of it.