### PR TITLE
Not to print "not found" in snapshot initialize, return the loaded path instead in autoload mode

### DIFF
--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -341,18 +341,16 @@ class _Snapshot(extension.Extension):
         outdir = manager.out
         writer = manager.writer if self.writer is None else self.writer
         self.writer = writer
+        loaded_fn = None
         if self.autoload:
             # If ``autoload`` is on, this code scans the ``outdir``
             # for potential snapshot files by matching the file names
             # from ``filename`` format, picks up the latest one in
             # terms of mtime, and tries to load it it the target or
             # manager.
-            filename = _find_latest_snapshot(self.filename, outdir, writer.fs)
-            if filename is None:
-                print('No snapshot file that matches {} was found'
-                      .format(self.filename))
-            else:
-                snapshot_file = writer.fs.open(os.path.join(outdir, filename))
+            loaded_fn = _find_latest_snapshot(self.filename, outdir, writer.fs)
+            if loaded_fn:
+                snapshot_file = writer.fs.open(os.path.join(outdir, loaded_fn))
                 # As described above (at ``autoload`` option),
                 # snapshot files to be autoloaded must be saved by
                 # ``save_npz`` . In order to support general format,
@@ -386,6 +384,8 @@ class _Snapshot(extension.Extension):
                     writer.fs.remove(os.path.join(outdir, file))
 
             writer._add_cleanup_hook(_cleanup)
+
+        return loaded_fn
 
     def on_error(self, manager, exc, tb):
         super().on_error(manager, exc, tb)

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
@@ -132,9 +132,21 @@ def test_multi_target_autoload(remover):
     snapshot2 = extensions.snapshot_object(target, 'myfile.dat',
                                            autoload=True)
     # Load the snapshot and verify it
-    snapshot2.initialize(new_trainer)
+    assert snapshot2.initialize(new_trainer) == 'myfile.dat'
     assert new_trainer.state_dict() == trainer.state_dict()
     assert new_other.state_dict() == other_state_dict
+
+
+def test_multi_target_autoload_not_found(remover):
+    trainer = get_trainer_with_mock_updater(out_dir='.')
+    other = _StateDictObj(state_dict={'original': 'state'})
+
+    target = {'trainer': trainer, 'other': other}
+    snapshot = extensions.snapshot_object(target, 'myfile.dat',
+                                          autoload=True)
+
+    assert snapshot.initialize(trainer) is None
+    assert other.state_dict() == {'original': 'state'}
 
 
 def test_clean_up_tempdir(remover):

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
@@ -138,7 +138,7 @@ def test_multi_target_autoload(remover):
 
 
 def test_multi_target_autoload_not_found(remover):
-    trainer = get_trainer_with_mock_updater(out_dir='.')
+    trainer = get_trainer(out_dir='.')
     other = _StateDictObj(state_dict={'original': 'state'})
 
     target = {'trainer': trainer, 'other': other}


### PR DESCRIPTION
`_Snapshot.initialize` with `autoload=True` prints the following message to stdout when there's no file to load.

```
No snapshot file that matches last_snapshot was found
```

In multi-GPU setting using MPI and torch.distributed, it leads to occupying the terminal screen with its repetition.

```
No snapshot file that matches last_snapshot was found
No snapshot file that matches last_snapshot was found
No snapshot file that matches last_snapshot was found
No snapshot file that matches last_snapshot was found
No snapshot file that matches last_snapshot was found
No snapshot file that matches last_snapshot was found
No snapshot file that matches last_snapshot was found
No snapshot file that matches last_snapshot was found
No snapshot file that matches last_snapshot was found
No snapshot file that matches last_snapshot was found
No snapshot file that matches last_snapshot was found
No snapshot file that matches last_snapshot was found
No snapshot file that matches last_snapshot was found
...
```

I know it is useful to let users know if the snapshot has autoloaded a snapshot, so I introduce a way to more programmatically notify it, so users can handle it as they want.
In summary this PR includes:

* Suppress stdout print.
* `snapshot.initialize` to return the file path that is actually loaded, or None if nothing (including the case the snapshot is `autoload=False`)

Although this should technically work, my concern is that auto-loading process might not be only the thing that `_Snapshot.initialize` is in charge in the future (although currently it almost is), so reserving its return value by the loaded filename could cause of future headache.