### PR TITLE
Avoid multiple writes and prints on distributed settings

### DIFF
--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -420,11 +420,11 @@ class _DistributedSnapshot(_Snapshot):
                          autoload, savefun)
         # To support distributed snapshots
         self._saver_rank = saver_rank
-        if not (0 <= saver_rank < self._size):
-            raise ValueError('Distributed snapshot requires a saver rank'
-                             ' in the range [0-{})'.format(self._size))
 
     def __call__(self, manager):
+        if not (0 <= self._saver_rank < manager.size):
+            raise ValueError('Distributed snapshot requires a saver rank'
+                             ' in the range [0-{})'.format(manager.size))
         if self.condition():
             # on distributed environments only the designed rank
             # saves the snapshot

--- a/pytorch_pfn_extras/training/extensions/log_report.py
+++ b/pytorch_pfn_extras/training/extensions/log_report.py
@@ -110,7 +110,8 @@ keys=None, trigger=(1, 'epoch'), postprocess=None, filename='log', writer=None)
             self._log.append(stats_cpu)
 
             # write to the log file
-            if self._log_name is not None:
+            # Do not execute in slave workers
+            if self._log_name is not None and manager.rank == 0:
                 log_name = self._log_name.format(**stats_cpu)
                 out = manager.out
                 writer(log_name, out, self._log, savefun=log_writer_save_func)

--- a/pytorch_pfn_extras/training/extensions/print_report.py
+++ b/pytorch_pfn_extras/training/extensions/print_report.py
@@ -121,6 +121,9 @@ class PrintReport(extension.Extension):
             self._templates = templates
 
     def __call__(self, manager):
+        # Do not print in slave workers
+        if manager.rank != 0:
+            return
         log_report = self.get_log_report(manager)
         log = log_report.log
 

--- a/pytorch_pfn_extras/training/extensions/progress_bar.py
+++ b/pytorch_pfn_extras/training/extensions/progress_bar.py
@@ -35,6 +35,9 @@ class ProgressBar(extension.Extension):
             self._training_length, self._bar_length, self._out)
 
     def __call__(self, manager):
+        # Do not print in slave workers
+        if manager.rank != 0:
+            return
         if self._pbar.manager is None:
             self._pbar.manager = manager
 

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_distributed_snapshot.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_distributed_snapshot.py
@@ -42,7 +42,7 @@ def _init_distributed(use_cuda):
             or 'MV2_COMM_WORLD_SIZE' in os.environ):
         # This test assumes NCCL backend.
         size, rank, local_rank = (
-            extensions._snapshot._get_ranks_from_env())
+            training.manager._get_ranks_from_env())
 
         if not torch.distributed.is_initialized():
             os.environ["WORLD_SIZE"] = str(size)


### PR DESCRIPTION
`ExtensionsManager` now holds the distributed `rank` information.

Some extensions that write to files or print to stdout do that action only in the master rank. However, they can be executed in the worker ranks without side-effects.

There are some issues such as, if in a distributed environment, maybe there is some scenario where we want the workers to write to a specific folder each, and abstract that through a writer. So I wonder if enforcing an only `rank==0` writing in the code base is good.

 