### PR TITLE
Added `SharedDataset`

### DIFF
--- a/pytorch_pfn_extras/dataset/__init__.py
+++ b/pytorch_pfn_extras/dataset/__init__.py
@@ -1,1 +1,3 @@
 from pytorch_pfn_extras.dataset.tabular.tabular_dataset import TabularDataset  # NOQA
+from pytorch_pfn_extras.dataset.shared_dataset import ItemNotFoundException  # NOQA
+from pytorch_pfn_extras.dataset.shared_dataset import SharedDataset  # NOQA

--- a/pytorch_pfn_extras/dataset/shared_dataset.py
+++ b/pytorch_pfn_extras/dataset/shared_dataset.py
@@ -1,0 +1,72 @@
+import ctypes
+import multiprocessing
+
+import numpy
+import torch
+
+
+class Cache:
+    def is_cached(self, idx):
+        raise NotImplementedError
+
+    def add_to_cache(self, idx, x):
+        raise NotImplementedError
+
+    def get_value(self, idx):
+        raise NotImplementedError
+
+
+class InfiniteCache(Cache):
+    def __init__(self, sm_size):
+        super().__init__()
+        self.sm_size = sm_size
+        total_size = 1
+        for x in sm_size:
+            total_size *= x
+        shared_memory = multiprocessing.Array(ctypes.c_float, total_size)
+        storage = numpy.ctypeslib.as_array(shared_memory.get_obj())
+        self.storage = storage.reshape(sm_size)
+        # This requires a continuous data loader for the cached values not
+        # to be lost
+        cached_ids = multiprocessing.Array(ctypes.c_bool, sm_size[0])
+        self.cached_ids = numpy.ctypeslib.as_array(cached_ids.get_obj())
+
+    def is_cached(self, idx):
+        return self.cached_ids[idx] == 1
+
+    def get_value(self, idx):
+        x = None
+        if self.is_cached(idx):
+            x = self.storage[idx]
+        return x
+
+    def add_to_cache(self, idx, x):
+        self.storage[idx] = x
+        self.cached_ids[idx] = 1
+
+
+class ItemNotFoundException(Exception):
+    pass
+
+
+class SharedDataset(torch.utils.data.Dataset):
+    """ Dataset that caches the load samples in shared memory
+
+    Args
+    """
+    def __init__(self, sm_size, cache_type=InfiniteCache):
+        super().__init__()
+        self.cache = cache_type(sm_size)
+
+    def __getitem__(self, idx):
+        x = self.cache.get_value(idx)
+        if x is None:
+            raise ItemNotFoundException(
+                'Item {} is not in the cache'.format(idx))
+        return x
+
+    def is_cached(self, idx):
+        return self.cache.is_cached(idx)
+
+    def cache_item(self, idx, x):
+        self.cache.add_to_cache(idx, x)

--- a/tests/pytorch_pfn_extras_tests/dataset_tests/test_shared_dataset.py
+++ b/tests/pytorch_pfn_extras_tests/dataset_tests/test_shared_dataset.py
@@ -1,0 +1,34 @@
+import pytorch_pfn_extras as ppe
+import torch
+
+
+class DummySharedDataset(ppe.dataset.SharedDataset):
+    def __init__(self):
+        self.data = torch.arange(100).reshape(100, 1)
+        super().__init__(self.data.shape)
+
+    def __getitem__(self, idx):
+        try:
+            x = super().__getitem__(idx)
+        except ppe.dataset.ItemNotFoundException:
+            x = self.data[idx]
+            self.cache_item(idx, x)
+        return x
+
+    def __len__(self):
+        return len(self.data)
+
+
+def test_empty_shared_dataset():
+    dataset = DummySharedDataset()
+    for i in range(100):
+        assert not dataset.is_cached(i)
+
+
+def test_shared_dataset():
+    dataset = DummySharedDataset()
+    dataloader = torch.utils.data.DataLoader(dataset, num_workers=0)
+    for x in dataloader:
+        pass
+    for i in range(100):
+        assert dataset.is_cached(i)


### PR DESCRIPTION
This PR is a complement of #43.

If workers are reused between epochs, the state of the dataset remains in memory. And moreover, images loaded by one worker can be stored in a shared memory space and made accessible to all workers, effectively increasing performance.

TODO:

pfio interplay