### PR TITLE
Error on `module.share_memory()` for uninitialized parameters.

### DIFF
--- a/pytorch_pfn_extras/nn/modules/lazy.py
+++ b/pytorch_pfn_extras/nn/modules/lazy.py
@@ -114,6 +114,12 @@ class UninitializedParameter(torch.nn.Parameter):
     def __repr__(self):
         return 'Uninitialized lazy parameter'
 
+    def share_memory_(self):
+        raise RuntimeError(
+            'Can\'t share memory on an unitialized parameter. '
+            'Run forward to initialize the network before calling '
+            '`module.share_memory()`.')
+
     @property
     def is_leaf(self):
         # Hacky workaround to detect use of uninitialized lazy parameters.

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py
@@ -96,6 +96,11 @@ class LazyTestBase:
         assert expected.shape == actual.shape
         assert (expected == actual).all()
 
+    def test_share_memory(self):
+        m1 = self.get_lazy_module()
+        with pytest.raises(RuntimeError):
+            m1.share_memory()
+
     def test_double(self):
         torch.manual_seed(0)
         input = self.get_input().double()


### PR DESCRIPTION
Uninitialized parameters can't share memory.