### PR TITLE
Use detach instead of clone to avoid retention of computational graph in reporter

### DIFF
--- a/pytorch_pfn_extras/reporting.py
+++ b/pytorch_pfn_extras/reporting.py
@@ -13,7 +13,7 @@ _thread_local = threading.local()
 
 def _copy_variable(value):
     if isinstance(value, torch.Tensor):
-        return value.clone()
+        return value.detach()
     return value
 
 

--- a/tests/pytorch_pfn_extras_tests/test_reporter.py
+++ b/tests/pytorch_pfn_extras_tests/test_reporter.py
@@ -158,6 +158,17 @@ def test_report_scope():
     assert 'x' not in reporter.observation
 
 
+def test_report_tensor_detached():
+    reporter = ppe.reporting.Reporter()
+    x = torch.tensor(numpy.array(1, 'float32'), requires_grad=True)
+    with reporter:
+        ppe.reporting.report({'x': x})
+    observation = reporter.observation
+    assert 'x' in observation
+    assert not observation['x'].requires_grad
+    assert x.requires_grad
+
+
 # ppe.reporting.Summary
 
 def test_summary_basic():


### PR DESCRIPTION
This fixes a memory leak that happens due to the reporter retaining the computational graph associated with the reported Tensor.