### PR TITLE
Fix resuming `Summary` reporting

### DIFF
--- a/pytorch_pfn_extras/reporting.py
+++ b/pytorch_pfn_extras/reporting.py
@@ -303,13 +303,9 @@ class Summary:
         return state
 
     def load_state_dict(self, to_load):
-        # TODO : still got warning `UserWarning: To copy construct from a tensor,
-        #        it is recommended to use sourceTensor.clone().detach() or
-        #        sourceTensor.clone().detach().requires_grad_(True),
-        #        rather than torch.tensor(sourceTensor).
-        self._x = torch.tensor(to_load['_x'], requires_grad = False)
-        self._x2 = torch.tensor(to_load['_x2'], requires_grad = False)
-        self._n = torch.tensor(to_load['_n'], requires_grad = False)
+        self._x = numpy.float64(to_load['_x'])
+        self._x2 = numpy.float64(to_load['_x2'])
+        self._n = numpy.float64(to_load['_n'])
 
 class DictSummary:
 

--- a/pytorch_pfn_extras/reporting.py
+++ b/pytorch_pfn_extras/reporting.py
@@ -303,10 +303,13 @@ class Summary:
         return state
 
     def load_state_dict(self, to_load):
-        self._x = to_load['_x']
-        self._x2 = to_load['_x2']
-        self._n = to_load['_n']
-
+        # TODO : still got warning `UserWarning: To copy construct from a tensor,
+        #        it is recommended to use sourceTensor.clone().detach() or
+        #        sourceTensor.clone().detach().requires_grad_(True),
+        #        rather than torch.tensor(sourceTensor).
+        self._x = torch.tensor(to_load['_x'], requires_grad = False)
+        self._x2 = torch.tensor(to_load['_x2'], requires_grad = False)
+        self._n = torch.tensor(to_load['_n'], requires_grad = False)
 
 class DictSummary:
 

--- a/tests/pytorch_pfn_extras_tests/test_reporter.py
+++ b/tests/pytorch_pfn_extras_tests/test_reporter.py
@@ -223,6 +223,19 @@ def test_summary_weight():
     numpy.testing.assert_allclose(mean.numpy(), val)
 
 
+def test_summary_resume():
+    summary = ppe.reporting.Summary()
+    summary.add(torch.tensor([[15.0]], requires_grad=True))
+
+    f = io.BytesIO()
+    torch.save(summary.state_dict(), f)
+    summary.load_state_dict(torch.load(io.BytesIO(f.getvalue())))
+
+    summary.add(5.0)
+    mean = summary.compute_mean()
+    numpy.testing.assert_allclose(mean, 10)
+
+
 def _check_summary_serialize(value1, value2, value3):
     summary = ppe.reporting.Summary()
     summary.add(value1)


### PR DESCRIPTION
This PR suggests to fix the resume procedure of `Summary` class.

I got a `RuntimeError` when resuming from some snapshots.
```
  File "./lib/python3.8/site-packages/pytorch_pfn_extras/training/extensions/log_report.py", line 90, in __call__
    summary.add(observation)
  File "./lib/python3.8/site-packages/pytorch_pfn_extras/reporting.py", line 342, in add
    summaries[k].add(v, weight=w)
  File "./lib/python3.8/site-packages/pytorch_pfn_extras/reporting.py", line 270, in add
    self._x += weight * value
RuntimeError: a leaf Variable that requires grad has been used in an in-place operation.
```

So I simply patch `Summary.load_state_dict` method as follows.
```Python
def load_state_dict(self, to_load):
        self._x = torch.tensor(to_load['_x'], requires_grad = False)
        self._x2 = torch.tensor(to_load['_x2'], requires_grad = False)
        self._n = torch.tensor(to_load['_n'], requires_grad = False)
```

But I still got warnings like 
```
UserWarning: To copy construct from a tensor,
        it is recommended to use sourceTensor.clone().detach() or
        sourceTensor.clone().detach().requires_grad_(True),
        rather than torch.tensor(sourceTensor).
```

Currently I'm not familiar with PyTorch, so it's hard to propose an appropriate solution for this issue.
I would be really grateful if anyone could discuss and solve this.

Thank you.
