### PR TITLE
Fix call timing of start_extension for correct resuming

### DIFF
--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -431,13 +431,13 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
 
         @self.engine.on(Events.STARTED)
         def set_training_started(engine):
+            self.start_extensions()
             start_iteration = self._start_iteration
             self.engine.state.iteration = self._start_iteration
             self.engine.state.epoch = self._start_epoch
             self._start_time = _get_time()
             iters_per_epoch = len(engine.state.dataloader)
             self._prepare_for_training(start_iteration, iters_per_epoch)
-            self.start_extensions()
 
             # Make all the next
             # handlers to be executed after user defined ones


### PR DESCRIPTION
If you run 5 epochs, stop, and then read the snapshot and run another 5 epochs, you will get the following results with the current code.

```
# The first run
epoch       elapsed_time  iteration   output
1           0.0010798     5           4
2           0.00373363    10          4
3           0.00604487    15          4
4           0.00874908    20          4
5           0.0116017     25          4
# The second run
epoch       elapsed_time  iteration   output
1           0.0010798     5           4
2           0.00373363    10          4
3           0.00604487    15          4
4           0.00874908    20          4
5           0.0116017     25          4
0           0.00103593    1           0
1           0.00377119    5           5
2           0.00678998    10          4
3           0.0101231     15          4
4           0.0127427     20          4
5           0.01506       25          4
6           0.017246      30          4
7           0.0198765     35          4
8           0.0220157     40          4
9           0.0256625     45          4
10          0.0280152     50          4
```

Iteration and epoch is not loaded correctly. Note that models and optimizers are loaded correctly. This is due to the timing of the loading process. `IgniteExtensionsManager.engine.state.iteration` is set as `0` before `_Snapshot.initialize` was performed by calling `IgniteExtensionsManager.start_extensions`, and the loaded IgniteExtensionsManager.iteration was overwritten by `0`.

This PR fixes this.

Minimal Reproducible Example
---

```
from typing import Tuple

import numpy as np
import pytorch_pfn_extras as ppe
import pytorch_pfn_extras.training.extensions as extensions
import torch
from ignite.engine import Engine, Events
from torch.utils.data import DataLoader


def training(nb_epoch: int, autoload: bool):
    def process_function(engine: Engine, batch: Tuple[torch.Tensor]) -> float:
        return batch[0].mean().item()

    trainer = Engine(process_function)

    @trainer.on(Events.ITERATION_COMPLETED)
    def report_loss(engine: Engine) -> None:
        ppe.reporting.report({"output": engine.state.output})

    my_extensions = [
        extensions.LogReport(),
        extensions.PrintReport(["epoch", "elapsed_time", "iteration", "output",]),
        extensions.snapshot(n_retains=1, autoload=autoload),
    ]

    dataloader = DataLoader(np.arange(10).astype(np.float32), batch_size=2)

    manager = ppe.training.IgniteExtensionsManager(trainer, {}, {}, nb_epoch, extensions=my_extensions)
    trainer.run(dataloader, max_epochs=nb_epoch)


training(5, False)
training(10, True)
```

