### PR TITLE
Fix extensions using matplotlib to emit warning only once

### DIFF
--- a/pytorch_pfn_extras/training/extensions/plot_report.py
+++ b/pytorch_pfn_extras/training/extensions/plot_report.py
@@ -141,7 +141,7 @@ filename='plot.png', marker='x', grid=True)
         return _available
 
     def __call__(self, manager):
-        if self.available():
+        if _available:
             # Dynamically import pyplot to call matplotlib.use()
             # after importing pytorch_pfn_extras.training.extensions
             import matplotlib.pyplot as plt

--- a/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
+++ b/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
@@ -260,7 +260,7 @@ grid=True)
         return _available
 
     def __call__(self, manager):
-        if self.available():
+        if _available:
             # Dynamically import pyplot to call matplotlib.use()
             # after importing pytorch_pfn_extras.training.extensions
             import matplotlib.pyplot as plt

--- a/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
+++ b/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
@@ -205,6 +205,8 @@ grid=True)
                  trigger=(1, 'epoch'), filename=None,
                  figsize=None, marker=None, grid=True, **kwargs):
 
+        _check_available()
+
         file_name = kwargs.get('file_name', 'statistics.png')
         if filename is None:
             filename = file_name


### PR DESCRIPTION
This fixes warnings to emit warnings only once in these extensions so that users won't see too many warnings when using `python -Wall`.