### PR TITLE
Fix IgniteExtensionsManager initialization

### DIFF
--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -1,18 +1,17 @@
 import collections
-import copy
 import contextlib
+import copy
 import os
 import time
 import warnings
 
 import torch
 
+from pytorch_pfn_extras import writing
+from pytorch_pfn_extras.reporting import Reporter
 from pytorch_pfn_extras.training import extension as extension_module
 from pytorch_pfn_extras.training import trigger as trigger_module
 from pytorch_pfn_extras.training import util as util_module
-from pytorch_pfn_extras.reporting import Reporter
-from pytorch_pfn_extras import writing
-
 
 # Select the best-resolution timer function
 try:
@@ -444,12 +443,15 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
 
         @self.engine.on(Events.STARTED)
         def set_training_started(engine):
+            iters_per_epoch = len(engine.state.dataloader)
+            # Initialize manager once before extensions' `initialize` are called.
+            self._prepare_for_training(0, iters_per_epoch)
             self.start_extensions()
             start_iteration = self._start_iteration
             self.engine.state.iteration = self._start_iteration
             self.engine.state.epoch = self._start_epoch
             self._start_time = _get_time()
-            iters_per_epoch = len(engine.state.dataloader)
+            # Initialize manager again after all state is restored.
             self._prepare_for_training(start_iteration, iters_per_epoch)
 
             # Make all the next

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -444,14 +444,14 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
         @self.engine.on(Events.STARTED)
         def set_training_started(engine):
             iters_per_epoch = len(engine.state.dataloader)
-            # Initialize manager once before extensions' `initialize` are called.
+            # Initialize manager once before extensions' `initialize` call
             self._prepare_for_training(0, iters_per_epoch)
             self.start_extensions()
             start_iteration = self._start_iteration
             self.engine.state.iteration = self._start_iteration
             self.engine.state.epoch = self._start_epoch
             self._start_time = _get_time()
-            # Initialize manager again after all state is restored.
+            # Initialize manager again after all state is restored
             self._prepare_for_training(start_iteration, iters_per_epoch)
 
             # Make all the next

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_progress_bar_notebook.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_progress_bar_notebook.py
@@ -1,8 +1,13 @@
 import io
 
 import pytest
+import torch
+from torch import nn
+from torch.nn import Linear
+from torch.optim.adam import Adam
 
 import pytorch_pfn_extras as ppe
+from pytorch_pfn_extras import training
 from pytorch_pfn_extras.training.extensions import _ipython_module_available
 
 
@@ -34,6 +39,51 @@ def test_run_progress_bar_notebook():
                 status = '{} iter, {} epoch / {} epochs'.format(
                     manager.iteration, epoch, max_epochs)
                 assert status in extension._status_html.value
+
+
+@pytest.mark.skipif(
+    not _ipython_module_available,
+    reason="progress bar notebook import failed, "
+           "maybe ipython is not installed"
+)
+def test_ignite_extensions_manager_with_progressbar_notebook():
+
+    try:
+        from ignite.engine import create_supervised_trainer
+    except ImportError:
+        pytest.skip('pytorch-ignite not found')
+
+    max_epochs = 5
+    iters_per_epoch = 4
+
+    class DummyModel(nn.Module):
+        def __init__(self):
+            super(DummyModel, self).__init__()
+            self.lin = Linear(1, 1)
+
+        def forward(self, *args):
+            pass
+
+    model = DummyModel()
+    optimizer = Adam(model.parameters())
+
+    def _fake_loss(*args):
+        return torch.tensor([0.0], requires_grad=True)
+
+    trainer = create_supervised_trainer(
+        model, optimizer, _fake_loss)
+
+    manager = training.IgniteExtensionsManager(
+        trainer,
+        {'model_name': model},
+        {'optimizer_name': optimizer},
+        max_epochs,
+    )
+    manager.extend(ppe.training.extensions.ProgressBarNotebook())
+
+    loader = torch.utils.data.DataLoader(
+        [(i, i) for i in range(iters_per_epoch)])
+    trainer.run(loader, max_epochs=max_epochs)
 
 
 if __name__ == '__main__':

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
@@ -341,3 +341,7 @@ def test_call_optimizers():
     with manager.run_iteration(step_optimizers=['main']):
         a.grad = torch.tensor([2.0])
     assert torch.equal(a.detach(), torch.tensor([-1.]))
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v', '-s'])


### PR DESCRIPTION
when extension accessed manager.iteration in their `initialize` method, it failed because it's not prepared yet. (happed in ProgressBarNotebook)
This PR fixes this.