### PR TITLE
Support built-in config types for Optuna

### DIFF
--- a/.flexci/test.sh
+++ b/.flexci/test.sh
@@ -2,7 +2,7 @@
 
 ln -s /opt/conda/bin/pip /opt/conda/bin/pip3
 # torch & torchvision is already installed.
-pip3 install pytorch-ignite pytest flake8 matplotlib tensorboard onnx ipython ipywidgets pandas
+pip3 install pytorch-ignite pytest flake8 matplotlib tensorboard onnx ipython ipywidgets pandas optuna
 # TODO(kmaehashi): fix to use stable version after v8 release
 pip3 install 'cupy-cuda101>=8.0.0rc1'
 pip3 install -e .

--- a/pytorch_pfn_extras/config_types.py
+++ b/pytorch_pfn_extras/config_types.py
@@ -4,12 +4,12 @@ from .config import Config
 
 def optuna_types(trial):
     types = {
-        "suggest_categorical": trial.suggest_categorical,
-        "suggest_discrete_uniform": trial.suggest_discrete_uniform,
-        "suggest_float": trial.suggest_float,
-        "suggest_int": trial.suggest_int,
-        "suggest_loguniform": trial.suggest_loguniform,
-        "suggest_uniform": trial.suggest_uniform,
+        "optuna_suggest_categorical": trial.suggest_categorical,
+        "optuna_suggest_discrete_uniform": trial.suggest_discrete_uniform,
+        "optuna_suggest_float": trial.suggest_float,
+        "optuna_suggest_int": trial.suggest_int,
+        "optuna_suggest_loguniform": trial.suggest_loguniform,
+        "optuna_suggest_uniform": trial.suggest_uniform,
     }
     return types
 

--- a/pytorch_pfn_extras/config_types.py
+++ b/pytorch_pfn_extras/config_types.py
@@ -1,0 +1,23 @@
+import warnings
+
+from .config import Config
+
+def optuna_types(trial):
+    types = {
+        "suggest_categorical": trial.suggest_categorical,
+        "suggest_discrete_uniform": trial.suggest_discrete_uniform,
+        "suggest_float": trial.suggest_float,
+        "suggest_int": trial.suggest_int,
+        "suggest_loguniform": trial.suggest_loguniform,
+        "suggest_uniform": trial.suggest_uniform,
+    }
+    return types
+
+def load_path_with_optuna_types(path, trial, loader=None, types=None):
+    if types is None:
+        types = {}
+    for key, value in optuna_types(trial).items():
+        if key in types:
+            warnings.warn(f'{key} is overwritten by optuna suggest.')
+        types[key] = value
+    return Config.load_path(path, loader=loader, types=types)

--- a/pytorch_pfn_extras/config_types.py
+++ b/pytorch_pfn_extras/config_types.py
@@ -2,6 +2,7 @@ import warnings
 
 from .config import Config
 
+
 def optuna_types(trial):
     types = {
         "optuna_suggest_categorical": trial.suggest_categorical,
@@ -12,6 +13,7 @@ def optuna_types(trial):
         "optuna_suggest_uniform": trial.suggest_uniform,
     }
     return types
+
 
 def load_path_with_optuna_types(path, trial, loader=None, types=None):
     if types is None:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     license='MIT License',
     install_requires=['numpy', 'torch'],
     extras_require={
-        'test': ['pytest', 'optuna'],
+        'test': ['pytest'],
         'onnx': ['onnx'],
     },
     packages=setuptools.find_packages(exclude=['tests']),

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     license='MIT License',
     install_requires=['numpy', 'torch'],
     extras_require={
-        'test': ['pytest'],
+        'test': ['pytest', 'optuna'],
         'onnx': ['onnx'],
     },
     packages=setuptools.find_packages(exclude=['tests']),

--- a/tests/pytorch_pfn_extras_tests/test_config_types.py
+++ b/tests/pytorch_pfn_extras_tests/test_config_types.py
@@ -1,0 +1,75 @@
+import os
+import tempfile
+import unittest
+
+import optuna
+
+from pytorch_pfn_extras.config_types import optuna_types
+from pytorch_pfn_extras.config_types import load_path_with_optuna_types
+
+
+class TestConfigTypes(unittest.TestCase):
+
+    study = optuna.create_study()
+
+    def test_config_optuna_types(self):
+        def objective(trial):
+            types = optuna_types(trial)
+            self.assertEqual(types['suggest_categorical'], trial.suggest_categorical)
+            self.assertEqual(types['suggest_discrete_uniform'], trial.suggest_discrete_uniform)
+            self.assertEqual(types['suggest_float'], trial.suggest_float)
+            self.assertEqual(types['suggest_int'], trial.suggest_int)
+            self.assertEqual(types['suggest_loguniform'], trial.suggest_loguniform)
+            self.assertEqual(types['suggest_uniform'], trial.suggest_uniform)
+            return 0.0
+        self.study.optimize(objective, n_trials=1)
+
+    def test_load_path_with_optuna_types(self):
+        low = 0
+        high = 8
+        def objective(trial):
+            with tempfile.TemporaryDirectory() as temp0:
+                with open(os.path.join(temp0, 'foo.json'), mode='w') as f:
+                    json.dump({
+                        'foo': {
+                            'type': 'suggest_int',
+                            'name': 'a',
+                            'low': low,
+                            'high': high
+                        }
+                    }, f)
+                config = load_path_with_optuna_types(os.path.join(temp0, 'foo.json'), trial)
+            self.assertIsInstance(config['/foo'], int)
+            self.assertGreaterEqual(config['/foo'], low)
+            self.assertLessEqual(config['/foo'], high)
+            return 0.0
+        self.study.optimize(objective, n_trials=2 * (high - low + 1))
+
+    def test_load_path_with_optuna_types_with_types_argument(self):
+        low = 0
+        high = 8
+        def objective(trial):
+            with tempfile.TemporaryDirectory() as temp0:
+                with open(os.path.join(temp0, 'foo.json'), mode='w') as f:
+                    json.dump({
+                        'foo': {
+                            'type': 'suggest_int',
+                            'name': 'a',
+                            'low': low,
+                            'high': high
+                        },
+                        'bar': {
+                            'type': 'dict',
+                            'x': 0
+                        }
+                    }, f)
+                config = load_path_with_optuna_types(
+                    os.path.join(temp0, 'foo.json'), trial,
+                    types={'suggest_int': float, 'dict': dict})
+            self.assertIsInstance(config['/foo'], int)
+            self.assertGreaterEqual(config['/foo'], low)
+            self.assertLessEqual(config['/foo'], high)
+            self.assertIsInstance(config['/bar'], dict)
+            self.assertEqual(config['/bar']['x'], 0)
+            return 0.0
+        self.study.optimize(objective, n_trials=2 * (high - low + 1))

--- a/tests/pytorch_pfn_extras_tests/test_config_types.py
+++ b/tests/pytorch_pfn_extras_tests/test_config_types.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import unittest
@@ -27,49 +28,49 @@ class TestConfigTypes(unittest.TestCase):
     def test_load_path_with_optuna_types(self):
         low = 0
         high = 8
-        def objective(trial):
-            with tempfile.TemporaryDirectory() as temp0:
-                with open(os.path.join(temp0, 'foo.json'), mode='w') as f:
-                    json.dump({
-                        'foo': {
-                            'type': 'suggest_int',
-                            'name': 'a',
-                            'low': low,
-                            'high': high
-                        }
-                    }, f)
+        with tempfile.TemporaryDirectory() as temp0:
+            with open(os.path.join(temp0, 'foo.json'), mode='w') as f:
+                json.dump({
+                    'foo': {
+                        'type': 'suggest_int',
+                        'name': 'a',
+                        'low': low,
+                        'high': high
+                    }
+                }, f)
+            def objective(trial):
                 config = load_path_with_optuna_types(os.path.join(temp0, 'foo.json'), trial)
-            self.assertIsInstance(config['/foo'], int)
-            self.assertGreaterEqual(config['/foo'], low)
-            self.assertLessEqual(config['/foo'], high)
-            return 0.0
-        self.study.optimize(objective, n_trials=2 * (high - low + 1))
+                self.assertIsInstance(config['/foo'], int)
+                self.assertGreaterEqual(config['/foo'], low)
+                self.assertLessEqual(config['/foo'], high)
+                return 0.0
+            self.study.optimize(objective, n_trials=2 * (high - low + 1))
 
     def test_load_path_with_optuna_types_with_types_argument(self):
         low = 0
         high = 8
-        def objective(trial):
-            with tempfile.TemporaryDirectory() as temp0:
-                with open(os.path.join(temp0, 'foo.json'), mode='w') as f:
-                    json.dump({
-                        'foo': {
-                            'type': 'suggest_int',
-                            'name': 'a',
-                            'low': low,
-                            'high': high
-                        },
-                        'bar': {
-                            'type': 'dict',
-                            'x': 0
-                        }
-                    }, f)
+        with tempfile.TemporaryDirectory() as temp0:
+            with open(os.path.join(temp0, 'foo.json'), mode='w') as f:
+                json.dump({
+                    'foo': {
+                        'type': 'suggest_int',
+                        'name': 'a',
+                        'low': low,
+                        'high': high
+                    },
+                    'bar': {
+                        'type': 'dict',
+                        'x': 0
+                    }
+                }, f)
+            def objective(trial):
                 config = load_path_with_optuna_types(
                     os.path.join(temp0, 'foo.json'), trial,
                     types={'suggest_int': float, 'dict': dict})
-            self.assertIsInstance(config['/foo'], int)
-            self.assertGreaterEqual(config['/foo'], low)
-            self.assertLessEqual(config['/foo'], high)
-            self.assertIsInstance(config['/bar'], dict)
-            self.assertEqual(config['/bar']['x'], 0)
-            return 0.0
-        self.study.optimize(objective, n_trials=2 * (high - low + 1))
+                self.assertIsInstance(config['/foo'], int)
+                self.assertGreaterEqual(config['/foo'], low)
+                self.assertLessEqual(config['/foo'], high)
+                self.assertIsInstance(config['/bar'], dict)
+                self.assertEqual(config['/bar']['x'], 0)
+                return 0.0
+            self.study.optimize(objective, n_trials=2 * (high - low + 1))

--- a/tests/pytorch_pfn_extras_tests/test_config_types.py
+++ b/tests/pytorch_pfn_extras_tests/test_config_types.py
@@ -16,12 +16,24 @@ class TestConfigTypes(unittest.TestCase):
     def test_config_optuna_types(self):
         def objective(trial):
             types = optuna_types(trial)
-            self.assertEqual(types['optuna_suggest_categorical'], trial.suggest_categorical)
-            self.assertEqual(types['optuna_suggest_discrete_uniform'], trial.suggest_discrete_uniform)
-            self.assertEqual(types['optuna_suggest_float'], trial.suggest_float)
-            self.assertEqual(types['optuna_suggest_int'], trial.suggest_int)
-            self.assertEqual(types['optuna_suggest_loguniform'], trial.suggest_loguniform)
-            self.assertEqual(types['optuna_suggest_uniform'], trial.suggest_uniform)
+            self.assertEqual(
+                types['optuna_suggest_categorical'],
+                trial.suggest_categorical)
+            self.assertEqual(
+                types['optuna_suggest_discrete_uniform'],
+                trial.suggest_discrete_uniform)
+            self.assertEqual(
+                types['optuna_suggest_float'],
+                trial.suggest_float)
+            self.assertEqual(
+                types['optuna_suggest_int'],
+                trial.suggest_int)
+            self.assertEqual(
+                types['optuna_suggest_loguniform'],
+                trial.suggest_loguniform)
+            self.assertEqual(
+                types['optuna_suggest_uniform'],
+                trial.suggest_uniform)
             return 0.0
         self.study.optimize(objective, n_trials=1)
 
@@ -38,8 +50,10 @@ class TestConfigTypes(unittest.TestCase):
                         'high': high
                     }
                 }, f)
+
             def objective(trial):
-                config = load_path_with_optuna_types(os.path.join(temp0, 'foo.json'), trial)
+                config = load_path_with_optuna_types(
+                    os.path.join(temp0, 'foo.json'), trial)
                 self.assertIsInstance(config['/foo'], int)
                 self.assertGreaterEqual(config['/foo'], low)
                 self.assertLessEqual(config['/foo'], high)
@@ -63,6 +77,7 @@ class TestConfigTypes(unittest.TestCase):
                         'x': 0
                     }
                 }, f)
+
             def objective(trial):
                 config = load_path_with_optuna_types(
                     os.path.join(temp0, 'foo.json'), trial,
@@ -73,4 +88,6 @@ class TestConfigTypes(unittest.TestCase):
                 self.assertIsInstance(config['/bar'], dict)
                 self.assertEqual(config['/bar']['x'], 0)
                 return 0.0
-            self.assertWarns(UserWarning, self.study.optimize, objective, n_trials=2 * (high - low + 1))
+            self.assertWarns(
+                UserWarning, self.study.optimize, objective,
+                n_trials=2 * (high - low + 1))

--- a/tests/pytorch_pfn_extras_tests/test_config_types.py
+++ b/tests/pytorch_pfn_extras_tests/test_config_types.py
@@ -16,12 +16,12 @@ class TestConfigTypes(unittest.TestCase):
     def test_config_optuna_types(self):
         def objective(trial):
             types = optuna_types(trial)
-            self.assertEqual(types['suggest_categorical'], trial.suggest_categorical)
-            self.assertEqual(types['suggest_discrete_uniform'], trial.suggest_discrete_uniform)
-            self.assertEqual(types['suggest_float'], trial.suggest_float)
-            self.assertEqual(types['suggest_int'], trial.suggest_int)
-            self.assertEqual(types['suggest_loguniform'], trial.suggest_loguniform)
-            self.assertEqual(types['suggest_uniform'], trial.suggest_uniform)
+            self.assertEqual(types['optuna_suggest_categorical'], trial.suggest_categorical)
+            self.assertEqual(types['optuna_suggest_discrete_uniform'], trial.suggest_discrete_uniform)
+            self.assertEqual(types['optuna_suggest_float'], trial.suggest_float)
+            self.assertEqual(types['optuna_suggest_int'], trial.suggest_int)
+            self.assertEqual(types['optuna_suggest_loguniform'], trial.suggest_loguniform)
+            self.assertEqual(types['optuna_suggest_uniform'], trial.suggest_uniform)
             return 0.0
         self.study.optimize(objective, n_trials=1)
 
@@ -32,7 +32,7 @@ class TestConfigTypes(unittest.TestCase):
             with open(os.path.join(temp0, 'foo.json'), mode='w') as f:
                 json.dump({
                     'foo': {
-                        'type': 'suggest_int',
+                        'type': 'optuna_suggest_int',
                         'name': 'a',
                         'low': low,
                         'high': high
@@ -53,7 +53,7 @@ class TestConfigTypes(unittest.TestCase):
             with open(os.path.join(temp0, 'foo.json'), mode='w') as f:
                 json.dump({
                     'foo': {
-                        'type': 'suggest_int',
+                        'type': 'optuna_suggest_int',
                         'name': 'a',
                         'low': low,
                         'high': high
@@ -66,7 +66,7 @@ class TestConfigTypes(unittest.TestCase):
             def objective(trial):
                 config = load_path_with_optuna_types(
                     os.path.join(temp0, 'foo.json'), trial,
-                    types={'suggest_int': float, 'dict': dict})
+                    types={'optuna_suggest_int': float, 'dict': dict})
                 self.assertIsInstance(config['/foo'], int)
                 self.assertGreaterEqual(config['/foo'], low)
                 self.assertLessEqual(config['/foo'], high)

--- a/tests/pytorch_pfn_extras_tests/test_config_types.py
+++ b/tests/pytorch_pfn_extras_tests/test_config_types.py
@@ -73,4 +73,4 @@ class TestConfigTypes(unittest.TestCase):
                 self.assertIsInstance(config['/bar'], dict)
                 self.assertEqual(config['/bar']['x'], 0)
                 return 0.0
-            self.study.optimize(objective, n_trials=2 * (high - low + 1))
+            self.assertWarns(UserWarning, self.study.optimize, objective, n_trials=2 * (high - low + 1))


### PR DESCRIPTION
ppe's config supports custom types. It seems nice to prepare built-in types for related libraries like Optuna. In this PR, I added 2 features, `optuna_types` and `load_path_with_optuna_types`.

## `optuna_types`
It returns types dictionary according to input trial. We need to update it when Optuna adds new types.

## `load_path_with_optuna_types`
It's similar to `Config.load_path`. The difference is default types. It adds `suggest_*` according to input trial. If input types already has `suggest_*` key, it warns.

---

In `pytorch_pfn_extras/config_types.py`, Optuna is never imported so that it does not require to install Optuna if user doesn't use it. But for test, it requires Optuna. Then `setup.py` is updated.