### PR TITLE
Prevent directory creation conflict error of Writer when combined with MPI

### DIFF
--- a/pytorch_pfn_extras/writing.py
+++ b/pytorch_pfn_extras/writing.py
@@ -175,8 +175,7 @@ class Writer:
         raise NotImplementedError
 
     def initialize(self, out_dir):
-        if not self.fs.exists(out_dir):
-            self.fs.makedirs(out_dir)
+        self.fs.makedirs(out_dir, exist_ok=True)
         self._initialized = True
 
     def __del__(self):


### PR DESCRIPTION
[`Writer.initialize`](https://github.com/pfnet/pytorch-pfn-extras/blob/v0.3.1/pytorch_pfn_extras/writing.py#L178-L179) tries to make a directory after checking its existence, which is not an atomic operation and sometimes causes of directory creation conflict.

This can be confirmed by the following simple reproduction (though it sometimes can't; please try a few times).

```python
# reproduce.py
import pytorch_pfn_extras as ppe
ppe.writing.SimpleWriter().initialize(out_dir='foo')
```

```bash
% for I in {0..100}; do sleep 1; echo $I; mpiexec -n 16 python reproduce.py; rm foo -r; done
0
1
2
3
4
5
Traceback (most recent call last):
  File "reproduce.py", line 3, in <module>
    writer.initialize(out_dir='foo')
  File "/blah/blah/pytorch_pfn_extras/writing.py", line 179, in initialize
    self.fs.makedirs(out_dir)
  File "/blah/blah/pytorch_pfn_extras/writing.py", line 108, in makedirs
    return os.makedirs(file_path, mode, exist_ok)
  File "/blah/blah/lib/python3.7/os.py", line 221, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: 'foo'
-------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code.. Per user-direction, the job has been aborted.
-------------------------------------------------------
--------------------------------------------------------------------------
mpiexec detected that one or more processes exited with non-zero status, thus causing
the job to be terminated. The first process to do so was:

  Process name: [[25185,1],2]
  Exit code:    1
--------------------------------------------------------------------------
```

This PR is to fix this problem.
Both `pytorch_pfn_extras/writing.py:_PosixFileSystem` and its compatible [pfio HDFS filesystem handler](https://github.com/pfnet/pfio/blob/master/pfio/filesystems/hdfs.py#L273) support `exist_ok` flag.

I'm afraid this PR itself is very hard to write tests.