### PR TITLE
Rename ExtensionManager.{_models,_optimizers} to {models,optimizers} respectively so that extensions can easily access them

### DIFF
--- a/pytorch_pfn_extras/training/extensions/fail_on_non_number.py
+++ b/pytorch_pfn_extras/training/extensions/fail_on_non_number.py
@@ -13,7 +13,7 @@ class FailOnNonNumber(extension.Extension):
     """
 
     def __call__(self, manager):
-        for name, model in manager._models.items():
+        for name, model in manager.models.items():
             for param in model.parameters():
                 if (not torch.isfinite(param).all()
                         or (param.grad is not None

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -80,17 +80,17 @@ class _BaseExtensionsManager:
             if not isinstance(models, torch.nn.Module):
                 raise ValueError(
                     'model must be an instance of dict or toch.nn.Module')
-            self._models = {'main': models}
+            self.models = {'main': models}
         else:
-            self._models = models
+            self.models = models
         if not isinstance(optimizers, dict):
             # TODO(ecastill) Optimizer type is not checked because of tests
             # using mocks and other classes
-            self._optimizers = {'main': optimizers}
+            self.optimizers = {'main': optimizers}
         else:
-            self._optimizers = optimizers
+            self.optimizers = optimizers
 
-        for name, model in self._models.items():
+        for name, model in self.models.items():
             self.reporter.add_observer(name, model)
             self.reporter.add_observers(
                 name, model.named_modules())
@@ -287,10 +287,10 @@ class _BaseExtensionsManager:
         to_save['_start_iteration'] = self.iteration
         # Save manager status ?
         to_save['models'] = {
-            name: transform_models(name, self._models[name]).state_dict()
-            for name in self._models}
-        to_save['optimizers'] = {name: self._optimizers[name].state_dict()
-                                 for name in self._optimizers}
+            name: transform_models(name, self.models[name]).state_dict()
+            for name in self.models}
+        to_save['optimizers'] = {name: self.optimizers[name].state_dict()
+                                 for name in self.optimizers}
         to_save['extensions'] = {name: self._extensions[name].state_dict()
                                  for name in self._extensions}
         return to_save
@@ -307,13 +307,13 @@ class _BaseExtensionsManager:
         """
         self._start_iteration = to_load['_start_iteration']
         self.iteration = self._start_iteration
-        for name in self._models:
+        for name in self.models:
             # TODO(ecastill) map_loc when loading the model and DDP check
-            self._models[name].load_state_dict(to_load['models'][name])
-            self._models[name] = transform_models(name, self._models[name])
+            self.models[name].load_state_dict(to_load['models'][name])
+            self.models[name] = transform_models(name, self.models[name])
 
-        for name in self._optimizers:
-            self._optimizers[name].load_state_dict(to_load['optimizers'][name])
+        for name in self.optimizers:
+            self.optimizers[name].load_state_dict(to_load['optimizers'][name])
 
         for name in self._extensions:
             self._extensions[name].load_state_dict(
@@ -380,10 +380,10 @@ class ExtensionsManager(_BaseExtensionsManager):
         with self.reporter.scope(self.observation):
             try:
                 for name in step_optimizers_names:
-                    self._optimizers[name].zero_grad()
+                    self.optimizers[name].zero_grad()
                 yield
                 for name in step_optimizers_names:
-                    self._optimizers[name].step()
+                    self.optimizers[name].step()
             finally:
                 # In chainer, the iteration count was increased
                 # just before calling the extensions, we need

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
@@ -370,4 +370,4 @@ def test_model_transformations(path):
         filename='test', autoload=True,
         autoload_transform_models=lambda n, x: Wrapper(x))
     snapshot.initialize(trainer)
-    assert isinstance(trainer._models['main'], Wrapper)
+    assert isinstance(trainer.models['main'], Wrapper)

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
@@ -325,7 +325,7 @@ def test_model_transformations():
     )
     new_manager.load_state_dict(
         state_dict, transform_models=lambda n, x: Wrapper(x))
-    assert isinstance(new_manager._models['main'], Wrapper)
+    assert isinstance(new_manager.models['main'], Wrapper)
 
 
 def test_call_optimizers():


### PR DESCRIPTION
`ExtensionManager` receives models and optimizers and stores them in its internal (in terms of pep8 standard) members.
We often want to access to those model and/or optimizer from an extension. In order to do so in the current interface, especially for a function-based extension created using the `make_extension` decorator, it has to access to the internal members ((1-1) in the example below) or something a little hacky ((1-2), (1-3)).

Therefore I think that it might be handy if such members are treated as "public" interfaces. This PR is to introduce this change by simply renaming {_models,_optimizers} to {models,optimizers}.

For example:

```python
# (1-1) Current interface
@ppe.training.extension.make_extension
def print_conv1_std(manager):
    v = manager._models['main'].conv1.weight.std().item()    # <-- access to the model through _models
    ppe.reporting.report({'conv1_std': v})


# (1-2) Current interface; if the user hesitates to access to underscored methods (nor defining a class)
@ppe.training.extension.make_extension
def print_conv1_std(model, manager):
    v = model.conv1.weight.std().item()
    ppe.reporting.report({'conv1_std': v})

manager.extend(partial(print_conv1_std, model))    # <--- Use partial when adding to the manager


# (1-3) Current interface; dynamic function definition

model = ...

@ppe.training.extension.make_extension
def print_conv1_std(manager):
    global model    # <---- necessary depending on the scope
    v = model.conv1.weight.std().item()    # <-- access to the model defined in the wider scope
    ppe.reporting.report({'conv1_std': v})

# (2) In this PR
@ppe.training.extension.make_extension
def print_conv1_std(manager):
    v = manager.models['main'].conv1.weight.std().item()
    ppe.reporting.report({'conv1_std': v})
```