### PR TITLE
Name inputs and remove unused inputs from testcase

### DIFF
--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -164,8 +164,14 @@ def export_testcase(
         input_names=input_names, **kwargs)
 
     # Remove unused inputs
-    used_input_index_list = [
-        input_names.index(input.name) for input in onnx_graph.graph.input]
+    # - When keep_initializers_as_inputs=True, inputs contains initializers.
+    #   So we have to filt initializers.
+    # - model.onnx is already issued, so we can modify args here.
+    initializer_names = [init.name for init in onnx_graph.graph.initializer]
+    used_input_index_list = []
+    for used_input in onnx_graph.graph.input:
+        if used_input.name not in initializer_names:
+            used_input_index_list.append(input_names.index(used_input.name))
     input_names = [input_names[i] for i in used_input_index_list]
     args = [args[i] for i in used_input_index_list]
 

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -157,6 +157,7 @@ def export_testcase(
     input_names = kwargs.pop(
         'input_names',
         ['input_{}'.format(i) for i in range(len(args))])
+    assert len(input_names) == len(args)
 
     onnx_graph, outs = _export(
         model, args, strip_large_tensor_data, large_tensor_threshold,

--- a/tests/pytorch_pfn_extras_tests/onnx/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx/test_export_testcase.py
@@ -314,7 +314,8 @@ def test_export_testcase_with_unused_input(keep_initializers_as_inputs):
 
     xmodel = onnx.load_model(os.path.join(output_dir, 'model.onnx'))
     assert xmodel.graph.input[0].name == 'input_0'
-    assert len(xmodel.graph.input) == 1 or xmodel.graph.input[1].name != 'input_1'
+    assert len(xmodel.graph.input) == 1 or \
+        xmodel.graph.input[1].name != 'input_1'
 
     # With input_names
     output_dir = _helper(
@@ -329,4 +330,5 @@ def test_export_testcase_with_unused_input(keep_initializers_as_inputs):
 
     xmodel = onnx.load_model(os.path.join(output_dir, 'model.onnx'))
     assert xmodel.graph.input[0].name == 'x'
-    assert len(xmodel.graph.input) == 1 or xmodel.graph.input[1].name != 'unused'
+    assert len(xmodel.graph.input) == 1 or \
+        xmodel.graph.input[1].name != 'unused'

--- a/tests/pytorch_pfn_extras_tests/onnx/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx/test_export_testcase.py
@@ -279,7 +279,7 @@ def test_export_testcase_options():
 
 class NetWithUnusedInput(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super(NetWithUnusedInput, self).__init__()
         self.conv1 = nn.Conv2d(1, 20, 5, 1)
         self.conv2 = nn.Conv2d(20, 50, 5, 1)
         self.fc1 = nn.Linear(4*4*50, 500)
@@ -298,25 +298,28 @@ class NetWithUnusedInput(nn.Module):
 
 @pytest.mark.parametrize("keep_initializers_as_inputs", [None, True, False])
 def test_export_testcase_with_unused_input(keep_initializers_as_inputs):
-    model = Net().to('cpu')
+    model = NetWithUnusedInput().to('cpu')
     x = torch.zeros((1, 1, 28, 28))
+    unused = torch.zeros((1,))
 
     # Without input_names
     output_dir = _helper(
-        model, x, 'net_with_unused_input_without_input_names',
+        model, args=(x, unused), d='net_with_unused_input_without_input_names',
         opset_version=11, strip_doc_string=False,
         keep_initializers_as_inputs=keep_initializers_as_inputs)
     assert os.path.isdir(output_dir)
     test_data_set_dir = os.path.join(output_dir, 'test_data_set_0')
     assert os.path.exists(os.path.join(test_data_set_dir, 'input_0.pb'))
     assert not os.path.exists(os.path.join(test_data_set_dir, 'input_1.pb'))
+
     xmodel = onnx.load_model(os.path.join(output_dir, 'model.onnx'))
-    assert len(xmodel.graph.input) == 1
+    assert keep_initializers_as_inputs or len(xmodel.graph.input) == 1
     assert xmodel.graph.input[0].name == 'input_0'
+    assert len(xmodel.graph.input) == 1 or xmodel.graph.input[1].name != 'input_1'
 
     # With input_names
     output_dir = _helper(
-        model, x, 'net_with_unused_input_with_input_names',
+        model, args=(x, unused), d='net_with_unused_input_with_input_names',
         opset_version=11, strip_doc_string=False,
         keep_initializers_as_inputs=keep_initializers_as_inputs,
         input_names=['x', 'unused'])
@@ -324,6 +327,8 @@ def test_export_testcase_with_unused_input(keep_initializers_as_inputs):
     test_data_set_dir = os.path.join(output_dir, 'test_data_set_0')
     assert os.path.exists(os.path.join(test_data_set_dir, 'input_0.pb'))
     assert not os.path.exists(os.path.join(test_data_set_dir, 'input_1.pb'))
+
     xmodel = onnx.load_model(os.path.join(output_dir, 'model.onnx'))
-    assert len(xmodel.graph.input) == 1
+    assert keep_initializers_as_inputs or len(xmodel.graph.input) == 1
     assert xmodel.graph.input[0].name == 'x'
+    assert len(xmodel.graph.input) == 1 or xmodel.graph.input[1].name != 'unused'

--- a/tests/pytorch_pfn_extras_tests/onnx/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx/test_export_testcase.py
@@ -275,3 +275,55 @@ def test_export_testcase_options():
         output_dir, 'model.onnx'), load_external_data=False)
     assert onnx_model.opset_import[0].version == 11
     assert onnx_model.graph.node[0].doc_string != ''
+
+
+class NetWithUnusedInput(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 20, 5, 1)
+        self.conv2 = nn.Conv2d(20, 50, 5, 1)
+        self.fc1 = nn.Linear(4*4*50, 500)
+        self.fc2 = nn.Linear(500, 10)
+
+    def forward(self, x, unused):
+        x = F.relu(self.conv1(x))
+        x = F.max_pool2d(x, 2, 2)
+        x = F.relu(self.conv2(x))
+        x = F.max_pool2d(x, 2, 2)
+        x = x.view(-1, 4*4*50)
+        x = F.relu(self.fc1(x))
+        x = self.fc2(x)
+        return F.log_softmax(x, dim=1)
+
+
+@pytest.mark.parametrize("keep_initializers_as_inputs", [None, True, False])
+def test_export_testcase_with_unused_input(keep_initializers_as_inputs):
+    model = Net().to('cpu')
+    x = torch.zeros((1, 1, 28, 28))
+
+    # Without input_names
+    output_dir = _helper(
+        model, x, 'net_with_unused_input_without_input_names',
+        opset_version=11, strip_doc_string=False,
+        keep_initializers_as_inputs=keep_initializers_as_inputs)
+    assert os.path.isdir(output_dir)
+    test_data_set_dir = os.path.join(output_dir, 'test_data_set_0')
+    assert os.path.exists(os.path.join(test_data_set_dir, 'input_0.pb'))
+    assert not os.path.exists(os.path.join(test_data_set_dir, 'input_1.pb'))
+    xmodel = onnx.load_model(os.path.join(output_dir, 'model.onnx'))
+    assert len(xmodel.graph.input) == 1
+    assert xmodel.graph.input[0].name == 'input_0'
+
+    # With input_names
+    output_dir = _helper(
+        model, x, 'net_with_unused_input_with_input_names',
+        opset_version=11, strip_doc_string=False,
+        keep_initializers_as_inputs=keep_initializers_as_inputs,
+        input_names=['x', 'unused'])
+    assert os.path.isdir(output_dir)
+    test_data_set_dir = os.path.join(output_dir, 'test_data_set_0')
+    assert os.path.exists(os.path.join(test_data_set_dir, 'input_0.pb'))
+    assert not os.path.exists(os.path.join(test_data_set_dir, 'input_1.pb'))
+    xmodel = onnx.load_model(os.path.join(output_dir, 'model.onnx'))
+    assert len(xmodel.graph.input) == 1
+    assert xmodel.graph.input[0].name == 'x'

--- a/tests/pytorch_pfn_extras_tests/onnx/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx/test_export_testcase.py
@@ -313,7 +313,6 @@ def test_export_testcase_with_unused_input(keep_initializers_as_inputs):
     assert not os.path.exists(os.path.join(test_data_set_dir, 'input_1.pb'))
 
     xmodel = onnx.load_model(os.path.join(output_dir, 'model.onnx'))
-    assert keep_initializers_as_inputs or len(xmodel.graph.input) == 1
     assert xmodel.graph.input[0].name == 'input_0'
     assert len(xmodel.graph.input) == 1 or xmodel.graph.input[1].name != 'input_1'
 
@@ -329,6 +328,5 @@ def test_export_testcase_with_unused_input(keep_initializers_as_inputs):
     assert not os.path.exists(os.path.join(test_data_set_dir, 'input_1.pb'))
 
     xmodel = onnx.load_model(os.path.join(output_dir, 'model.onnx'))
-    assert keep_initializers_as_inputs or len(xmodel.graph.input) == 1
     assert xmodel.graph.input[0].name == 'x'
     assert len(xmodel.graph.input) == 1 or xmodel.graph.input[1].name != 'unused'


### PR DESCRIPTION
When not given input_names, inputs are named by torch.onnx. The naming rule is not controllable and seems inconsistent, so we should name inputs by ourself.
With our naming, we can detect unused inputs and remove them from testcases.