### PR TITLE
Add `LRScheduler` extension

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -8,6 +8,7 @@ Currently the following extensions are available:
 
 + `Evaluator`
 + `LogReport`
++ `LRScheduler`
 + `MicroAverage`
 + `PrintReport`
 + `ProgressBar`

--- a/pytorch_pfn_extras/training/extensions/__init__.py
+++ b/pytorch_pfn_extras/training/extensions/__init__.py
@@ -4,6 +4,7 @@ from pytorch_pfn_extras.training.extensions._snapshot import snapshot_object  # 
 from pytorch_pfn_extras.training.extensions.evaluator import Evaluator, IgniteEvaluator  # NOQA
 from pytorch_pfn_extras.training.extensions.fail_on_non_number import FailOnNonNumber  # NOQA
 from pytorch_pfn_extras.training.extensions.log_report import LogReport  # NOQA
+from pytorch_pfn_extras.training.extensions.lr_scheduler import LRScheduler  # NOQA
 from pytorch_pfn_extras.training.extensions.micro_average import MicroAverage  # NOQA
 from pytorch_pfn_extras.training.extensions.print_report import PrintReport  # NOQA
 from pytorch_pfn_extras.training.extensions.progress_bar import ProgressBar  # NOQA

--- a/pytorch_pfn_extras/training/extensions/lr_scheduler.py
+++ b/pytorch_pfn_extras/training/extensions/lr_scheduler.py
@@ -1,0 +1,19 @@
+from pytorch_pfn_extras.training import extension
+
+
+class LRScheduler(extension.Extension):
+    """Wraps a `torch.optim.lr_scheduler` extension
+    so it will be called after the corresponding iteration.
+    This allows to take snapshots and automatically step them.
+    """
+    def __init__(self, torch_lr_scheduler):
+        self._lr_scheduler = torch_lr_scheduler
+
+    def __call__(self, manager):
+        self._lr_scheduler.step()
+
+    def state_dict(self):
+        return self._lr_scheduler.state_dict()
+
+    def load_state_dict(self, state):
+        self._lr_scheduler.load_state_dict(state)

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_lr_scheduler.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_lr_scheduler.py
@@ -1,0 +1,28 @@
+import torch
+
+import pytorch_pfn_extras as ppe
+
+
+def test_lr_scheduler():
+    param = torch.nn.Parameter(torch.zeros(10))
+    optim = torch.optim.SGD([param], 1.0)
+    sched = torch.optim.lr_scheduler.MultiStepLR(
+        optim, milestones=[10, 20, 30], gamma=0.1, last_epoch=-1
+    )
+    ext = ppe.training.extensions.LRScheduler(sched)
+    manager = ppe.training.ExtensionsManager(
+        {}, {'main': optim}, 1, extensions=[ext], iters_per_epoch=40)
+    for i in range(40):
+        with manager.run_iteration(step_optimizers=['main']):
+            if i < 10:
+                assert optim.param_groups[0]['lr'] > 0.99
+                assert optim.param_groups[0]['lr'] < 1.1
+            elif i < 20:
+                assert optim.param_groups[0]['lr'] > 0.09
+                assert optim.param_groups[0]['lr'] < 0.11
+            elif i < 30:
+                assert optim.param_groups[0]['lr'] > 0.009
+                assert optim.param_groups[0]['lr'] < 0.011
+            elif i < 40:
+                assert optim.param_groups[0]['lr'] > 0.0009
+                assert optim.param_groups[0]['lr'] < 0.0011


### PR DESCRIPTION
Needed for an easily interoperability of pytorch lr schedulers and ppe. This will automatically call step and take snapshots when required