### PR TITLE
[ONNX] Use 0 instead of os.EX_OK

### DIFF
--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -37,7 +37,7 @@ def _export_meta(model, out_dir, strip_large_tensor_data):
 
         def strip_cmd(cmd):
             return os.popen(cmd).read().strip()
-        if git_status.returncode == os.EX_OK:
+        if git_status.returncode == 0:
             ret['git'] = {
                 'branch': strip_cmd('git rev-parse --abbrev-ref HEAD'),
                 'commit': strip_cmd('git rev-parse HEAD'),


### PR DESCRIPTION
Apparently, os.EX_OK does not exist on Windows.

The document of subprocess says it returns 0 on success. The
document of os says some exit code may not be available. Thus
it would be better not to rely on os.EX_OK.