### PR TITLE
Fix parse error of torch version

### DIFF
--- a/tests/pytorch_pfn_extras_tests/nn_tests/parallel_tests/test_distributed.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/parallel_tests/test_distributed.py
@@ -1,7 +1,9 @@
-import numpy as np
 import os
 import torch
 import tempfile
+from packaging import version
+
+import numpy as np
 import pytest
 from torch import multiprocessing as mp
 from torch import distributed as dist
@@ -10,7 +12,7 @@ from torch.utils.checkpoint import checkpoint
 from pytorch_pfn_extras.nn.parallel import DistributedDataParallel
 
 
-torch_version = tuple([int(x) for x in torch.__version__.split(".")])
+torch_version = version.Version(torch.__version__)
 context = mp.get_context("spawn")
 
 
@@ -243,7 +245,7 @@ class TestDistributedDataParallel:
 
     @pytest.mark.parametrize('device_type', _device_types())
     @pytest.mark.skipif(
-        torch_version < (1, 6, 0),
+        torch_version < version.Version('1.6.0'),
         reason="Variable._execution_engine.queue_callback does not work "
                "with checkpointing when torch < 1.6.0")
     def test_checkpoint(self, device_type):


### PR DESCRIPTION
This PR fixes parse error of torch version in case of local version identifier s specified.