### PR TITLE
Fix snapshot not closing file

### DIFF
--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -367,6 +367,7 @@ class _Snapshot(extension.Extension):
                         target[k].load_state_dict(state[k], **kwargs)
                 else:
                     target.load_state_dict(state, **kwargs)
+                writer.fs.close(snapshot_file)
 
         if (hasattr(writer, '_add_cleanup_hook')
                 and self.n_retains > 0

--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -367,7 +367,7 @@ class _Snapshot(extension.Extension):
                         target[k].load_state_dict(state[k], **kwargs)
                 else:
                     target.load_state_dict(state, **kwargs)
-                writer.fs.close(snapshot_file)
+                snapshot_file.close()
 
         if (hasattr(writer, '_add_cleanup_hook')
                 and self.n_retains > 0

--- a/pytorch_pfn_extras/writing.py
+++ b/pytorch_pfn_extras/writing.py
@@ -89,8 +89,8 @@ class _PosixFileSystem(object):
     def stat(self, path):
         return _PosixFileStat(os.stat(path), path)
 
-    def close(self):
-        pass
+    def close(self, file_stream):
+        file_stream.close()
 
     def __enter__(self):
         return self

--- a/pytorch_pfn_extras/writing.py
+++ b/pytorch_pfn_extras/writing.py
@@ -89,8 +89,8 @@ class _PosixFileSystem(object):
     def stat(self, path):
         return _PosixFileStat(os.stat(path), path)
 
-    def close(self, file_stream):
-        file_stream.close()
+    def close(self):
+        pass
 
     def __enter__(self):
         return self


### PR DESCRIPTION
Leaving files unclosed in the autoload causes a warning that triggers and exception in the latest pytest version 