### PR TITLE
Add user_meta into meta.json

### DIFF
--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -43,7 +43,7 @@ def _model_to_graph_with_value_names(*args, add_value_names=True, **kwargs):
     return g, p, o
 
 
-def _export_meta(model, out_dir, strip_large_tensor_data, **user_meta):
+def _export_meta(model, out_dir, strip_large_tensor_data, user_meta):
     ret = {
         'generated_at': datetime.datetime.now().isoformat(),
         'output_directory': out_dir,
@@ -294,7 +294,7 @@ def export_testcase(
     if metadata:
         with open(os.path.join(out_dir, 'meta.json'), 'w') as f:
             json.dump(_export_meta(model, out_dir, strip_large_tensor_data,
-                                   **user_meta), f, indent=2)
+                                   user_meta), f, indent=2)
     elif user_meta:
         warnings.warn(
             '"user_meta" is given but "metadata" is False. '

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -301,6 +301,5 @@ def export_testcase(
             '"user_meta" is not exported.',
             UserWarning)
 
-
     if return_output:
         return outs

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -43,13 +43,16 @@ def _model_to_graph_with_value_names(*args, add_value_names=True, **kwargs):
     return g, p, o
 
 
-def _export_meta(model, out_dir, strip_large_tensor_data):
+def _export_meta(model, out_dir, strip_large_tensor_data, **user_meta):
     ret = {
         'generated_at': datetime.datetime.now().isoformat(),
         'output_directory': out_dir,
         'exporter': 'torch-onnx-utils',
         'strip_large_tensor_data': strip_large_tensor_data,
     }
+    if user_meta:
+        ret['user_meta'] = user_meta
+
     try:
         git_status = subprocess.Popen(['git', 'status'],
                                       stdout=subprocess.PIPE,
@@ -168,7 +171,7 @@ def export_testcase(
         model, args, out_dir, *, output_grad=False, metadata=True,
         model_overwrite=True, strip_large_tensor_data=False,
         large_tensor_threshold=LARGE_TENSOR_DATA_THRESHOLD,
-        return_output=False, **kwargs):
+        return_output=False, user_meta={}, **kwargs):
     """Export model and I/O tensors of the model in protobuf format.
 
     Args:
@@ -290,8 +293,14 @@ def export_testcase(
 
     if metadata:
         with open(os.path.join(out_dir, 'meta.json'), 'w') as f:
-            json.dump(_export_meta(model, out_dir,
-                                   strip_large_tensor_data), f, indent=2)
+            json.dump(_export_meta(model, out_dir, strip_large_tensor_data,
+                                   **user_meta), f, indent=2)
+    elif user_meta:
+        warnings.warn(
+            '"user_meta" is given but "metadata" is False. '
+            '"user_meta" is not exported.',
+            UserWarning)
+
 
     if return_output:
         return outs

--- a/tests/pytorch_pfn_extras_tests/onnx/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx/test_export_testcase.py
@@ -363,3 +363,23 @@ def test_export_testcase_with_unused_input(keep_initializers_as_inputs):
     assert xmodel.graph.input[0].name == 'x'
     assert len(xmodel.graph.input) == 1 or \
         xmodel.graph.input[1].name != 'unused'
+
+
+def test_user_meta():
+    model = nn.Sequential(nn.Linear(5, 10, bias=False))
+    x = torch.ones((2, 5))
+
+    output_dir = _helper(model, x, 'meta_without_user_meta', metadata=True)
+    with open(os.path.join(output_dir, "meta.json")) as metaf:
+        assert "user_meta" not in json.load(metaf)
+
+    output_dir = _helper(model, x, 'meta_with_user_meta', metadata=True,
+                         user_meta={"user_key": "user_value"})
+    with open(os.path.join(output_dir, "meta.json")) as metaf:
+        assert json.load(metaf)["user_meta"]["user_key"] == "user_value"
+
+    with pytest.warns(UserWarning):
+        output_dir = _helper(model, x, 'without_meta_with_user_meta',
+                             metadata=False,
+                             user_meta={"user_key": "user_value"})
+        assert not os.path.exists(os.path.join(output_dir, 'meta.json'))


### PR DESCRIPTION
Sometimes users want to add their own meta data into testcases. There is already `meta.json` so I made `export_testcase` can do that.