### PR TITLE
Fix autoload and transform models conflict

### DIFF
--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
@@ -361,13 +361,3 @@ def test_model_transformations(path):
     snapshot(manager)
 
     assert model.accessed
-
-    # Verify that autoload applies the transformation
-    to_load = torch.load(os.path.join(path, 'test'))
-    trainer = get_trainer(
-        out_dir=path, state_to_load=to_load)
-    snapshot = extensions.snapshot(
-        filename='test', autoload=True,
-        autoload_transform_models=lambda n, x: Wrapper(x))
-    snapshot.initialize(trainer)
-    assert isinstance(trainer.models['main'], Wrapper)

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
@@ -318,13 +318,13 @@ def test_model_transformations():
     new_model = _StateDictModel(state_dict_to_be_loaded=model_state_dict)
     new_optimizer = _StateDictObj(state_dict_to_be_loaded=optimizer_state_dict)
     new_manager = training.ExtensionsManager(
-        new_model,
+        Wrapper(new_model),
         new_optimizer,
         max_epochs,
         iters_per_epoch=iters_per_epoch,
     )
     new_manager.load_state_dict(
-        state_dict, transform_models=lambda n, x: Wrapper(x))
+        state_dict, transform_models=lambda n, x: x.wrapper_module())
     assert isinstance(new_manager.models['main'], Wrapper)
 
 


### PR DESCRIPTION
When loading a model wrapped in DDP or already transformed.
The logic for transforming the model should be the opposite of what we used to do.
Otherwise, autoload will require to modify the script when we want to resume the training.

With this PR, `autoload_transform_models` now has no sense.