### PR TITLE
Add BN aware checkpointing

### DIFF
--- a/pytorch_pfn_extras/__init__.py
+++ b/pytorch_pfn_extras/__init__.py
@@ -5,5 +5,6 @@ from pytorch_pfn_extras import dataloaders  # NOQA
 from pytorch_pfn_extras import nn  # NOQA
 from pytorch_pfn_extras import reporting  # NOQA
 from pytorch_pfn_extras import training  # NOQA
+from pytorch_pfn_extras import utils  # NOQA
 from pytorch_pfn_extras import writing  # NOQA
 from pytorch_pfn_extras._version import __version__  # NOQA

--- a/pytorch_pfn_extras/utils/__init__.py
+++ b/pytorch_pfn_extras/utils/__init__.py
@@ -1,0 +1,1 @@
+from pytorch_pfn_extras.utils import checkpoint  # NOQA

--- a/pytorch_pfn_extras/utils/checkpoint.py
+++ b/pytorch_pfn_extras/utils/checkpoint.py
@@ -10,8 +10,8 @@ class _CheckpointFunction(torch.utils.checkpoint.CheckpointFunction):
     momentum is updated twice, while we only need one update to ensure
     correctness.
     Using `ppe.utils.checkpointing.checkpoint` as a drop-in replacement
-    can help to lead with incorrect values in the backward pass generated
-    by this issue.
+    can help deal with incorrect values in the BatchNormalization
+    persistent parameters.
     """
     @staticmethod
     def forward(ctx, run_function, preserve_rng_state, *args):

--- a/pytorch_pfn_extras/utils/checkpoint.py
+++ b/pytorch_pfn_extras/utils/checkpoint.py
@@ -1,0 +1,42 @@
+import torch.utils.checkpoint
+
+
+class _CheckpointFunction(torch.utils.checkpoint.CheckpointFunction):
+    """Checkpoint a model or part of the model with BN support.
+
+    Refer to https://pytorch.org/docs/stable/checkpoint.html
+    for detailed information.
+    When using checkpointing in model using BatchNormalization, the
+    momentum is updated twice, while we only need one update to ensure
+    correctness.
+    Using `ppe.utils.checkpointing.checkpoint` as a drop-in replacement
+    can help to lead with incorrect values in the backward pass generated
+    by this issue.
+    """
+    @staticmethod
+    def forward(ctx, run_function, preserve_rng_state, *args):
+        _patch_bn_momentum(run_function)
+        return super(_CheckpointFunction, _CheckpointFunction).forward(
+            ctx, run_function, preserve_rng_state, *args)
+
+
+def _patch_bn_momentum(module):
+    if not hasattr(module, '_bn_momentum_patched'):
+        if isinstance(module, torch.nn.modules.instancenorm._InstanceNorm):
+            return
+        if isinstance(module, torch.nn.modules.batchnorm._BatchNorm):
+            # Set momentum so that two forward passes will produce the same
+            # EMA as one forward pass.
+            module.momentum = 1 - (1 - module.momentum) ** 0.5
+        for name, child in module.named_children():
+            _patch_bn_momentum(child)
+    module._bn_momentum_patched = True
+
+
+def checkpoint(function, *args, **kwargs):
+    # Hack to mix *args with **kwargs in a python 2.7-compliant way
+    preserve = kwargs.pop('preserve_rng_state', True)
+    if kwargs:
+        raise ValueError(
+            'Unexpected keyword arguments: ' + ','.join(arg for arg in kwargs))
+    return _CheckpointFunction.apply(function, preserve, *args)

--- a/tests/pytorch_pfn_extras_tests/utils_tests/test_checkpoint.py
+++ b/tests/pytorch_pfn_extras_tests/utils_tests/test_checkpoint.py
@@ -1,0 +1,62 @@
+import torch
+
+import pytorch_pfn_extras as ppe
+
+
+class SubNet(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = torch.nn.Conv2d(5, 5, 3, 1, 1)
+        self.bn1 = torch.nn.BatchNorm2d(5)
+
+    def forward(self, x):
+        return self.bn1(self.conv1(x)).relu()
+
+
+class Net(torch.nn.Module):
+    def __init__(self, checkpoint_type):
+        super().__init__()
+        self.checkpoint_type = checkpoint_type
+
+        self.conv1 = torch.nn.Conv2d(1, 5, 3, 1, 1)
+        self.bn1 = torch.nn.BatchNorm2d(5)
+        self.part1 = SubNet()
+        self.part2 = SubNet()
+
+    def forward(self, x):
+        x = self.bn1(self.conv1(x)).relu()
+
+        if self.checkpoint_type == 'none':
+            x = self.part1(x)
+        elif self.checkpoint_type == 'bnaware':
+            x = ppe.utils.checkpoint.checkpoint(self.part1, x)
+
+        x = self.part2(x)
+
+        return x
+
+
+def _get_bn_stats_test_checkpoint(cp_type):
+    torch.manual_seed(42)
+    net = Net(cp_type)
+    opt = torch.optim.SGD(net.parameters(), lr=0.1)
+    h, w = 32, 32
+
+    bn = net.part1.bn1
+
+    for epoch in range(2):
+        x = torch.arange(2 * h * w).reshape((2, 1, h, w)).float()
+
+        opt.zero_grad()
+        y = net(x)
+        y.sum().backward()
+        opt.step()
+
+    return (bn.weight, bn.bias, bn.running_mean, bn.running_var)
+
+
+def test_checkpoint():
+    baseline = _get_bn_stats_test_checkpoint('none')
+    ckpt = _get_bn_stats_test_checkpoint('bnaware')
+    for p_b, p_c in zip(baseline, ckpt):
+        assert torch.allclose(p_b, p_c)


### PR DESCRIPTION
`torch.utils.checkpoint` is not dealing correctly with batch normalization updating the internal stats twice as two forward passes are done. 
This PR is a solution implemented by @tkerola (all credit is his!) that reduces the momentum so both updates result in the same end value.