### PR TITLE
Fix CI error due to new numpy

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,5 +11,6 @@ filterwarnings =
     # numpy 1.20 deprecation for builtin alias referencing
     ignore:.*is a deprecated alias for the builtin:DeprecationWarning:onnx
     ignore:.*is a deprecated alias for the builtin:DeprecationWarning:tensorboard
+    ignore:.*is a deprecated alias for the builtin `bool`
 markers =
     gpu: Tests that require GPU


### PR DESCRIPTION
Temporary skip numpy 1.20 deprecation warning as the most stable cupy version does not have guaranteed support for it.