### PR TITLE
Fix long keys in from_data

### DIFF
--- a/pytorch_pfn_extras/dataset/tabular/from_data.py
+++ b/pytorch_pfn_extras/dataset/tabular/from_data.py
@@ -103,6 +103,8 @@ def _make_dataset(key, data, size):
         if size is None:
             raise ValueError('size must be specified for callable')
         dataset = _Index(size)
+        if isinstance(key, str):
+            key = key,
         if not isinstance(key, tuple):
             key = tuple(key)
         data = [((dataset.keys, key), data)]

--- a/tests/pytorch_pfn_extras_tests/dataset_tests/tabular_tests/test_from_data.py
+++ b/tests/pytorch_pfn_extras_tests/dataset_tests/tabular_tests/test_from_data.py
@@ -83,7 +83,8 @@ class TestFromData:
 
     def test_unary_callable_dict(self):
         dataset = tabular.from_data(
-            (('key_a', 'key_b'), lambda i: {'key_a': i * i, 'key_b': -i}), size=10)
+            (('key_a', 'key_b'),
+             lambda i: {'key_a': i * i, 'key_b': -i}), size=10)
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
@@ -148,7 +149,8 @@ class TestFromData:
         assert isinstance(output[1], list)
 
     def test_tuple_array_callable_unary(self):
-        dataset = tabular.from_data((np.arange(10), ('key_b', lambda i: i * i)))
+        dataset = tabular.from_data(
+             (np.arange(10), ('key_b', lambda i: i * i)))
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
@@ -178,7 +180,8 @@ class TestFromData:
 
     def test_tuple_array_callable_dict(self):
         dataset = tabular.from_data(
-            (np.arange(10), (('key_b', 'key_c'), lambda i: {'key_b': i * i, 'key_c': -i})))
+            (np.arange(10), (('key_b', 'key_c'),
+             lambda i: {'key_b': i * i, 'key_c': -i})))
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
@@ -221,7 +224,8 @@ class TestFromData:
 
     def test_tuple_callable_unary_callable_unary_without_size(self):
         with pytest.raises(ValueError):
-            tabular.from_data((('key_a', lambda i: i * i), ('key_b', lambda i: -i)))
+            tabular.from_data(
+                (('key_a', lambda i: i * i), ('key_b', lambda i: -i)))
 
     def test_dict_array_list(self):
         dataset = tabular.from_data(
@@ -238,7 +242,8 @@ class TestFromData:
         assert isinstance(output['key_b'], list)
 
     def test_dict_array_callable_unary(self):
-        dataset = tabular.from_data({'key_a': np.arange(10), 'key_b': lambda i: i * i})
+        dataset = tabular.from_data(
+            {'key_a': np.arange(10), 'key_b': lambda i: i * i})
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
@@ -252,7 +257,8 @@ class TestFromData:
 
     def test_dict_array_callable_tuple(self):
         dataset = tabular.from_data(
-            {'key_a': np.arange(10), ('key_b', 'key_c'): lambda i: (i * i, -i)})
+            {'key_a': np.arange(10),
+             ('key_b', 'key_c'): lambda i: (i * i, -i)})
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
@@ -268,7 +274,8 @@ class TestFromData:
 
     def test_dict_array_callable_dict(self):
         dataset = tabular.from_data(
-            {'key_a': np.arange(10), ('key_b', 'key_c'): lambda i: {'key_b': i * i, 'key_c': -i}})
+            {'key_a': np.arange(10),
+             ('key_b', 'key_c'): lambda i: {'key_b': i * i, 'key_c': -i}})
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
@@ -297,7 +304,8 @@ class TestFromData:
 
     def test_dict_callable_unary_callable_unary_without_size(self):
         with pytest.raises(ValueError):
-            tabular.from_data(({'key_a': lambda i: i * i, 'key_b': lambda i: -i}))
+            tabular.from_data((
+                {'key_a': lambda i: i * i, 'key_b': lambda i: -i}))
 
     def test_unique(self):
         dataset_a = tabular.from_data(np.arange(10))

--- a/tests/pytorch_pfn_extras_tests/dataset_tests/tabular_tests/test_from_data.py
+++ b/tests/pytorch_pfn_extras_tests/dataset_tests/tabular_tests/test_from_data.py
@@ -20,11 +20,11 @@ class TestFromData:
         assert isinstance(output, np.ndarray)
 
     def test_unary_array_with_key(self):
-        dataset = tabular.from_data(('a', np.arange(10)))
+        dataset = tabular.from_data(('key_a', np.arange(10)))
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
-        assert dataset.keys == ('a',)
+        assert dataset.keys == ('key_a',)
         assert dataset.mode is None
 
         output = dataset.slice[[1, 3]].fetch()
@@ -44,11 +44,11 @@ class TestFromData:
         assert isinstance(output, list)
 
     def test_unary_list_with_key(self):
-        dataset = tabular.from_data(('a', [2, 7, 1, 8, 4, 5, 9, 0, 3, 6]))
+        dataset = tabular.from_data(('key_a', [2, 7, 1, 8, 4, 5, 9, 0, 3, 6]))
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
-        assert dataset.keys == ('a',)
+        assert dataset.keys == ('key_a',)
         assert dataset.mode is None
 
         output = dataset.slice[[1, 3]].fetch()
@@ -56,11 +56,11 @@ class TestFromData:
         assert isinstance(output, list)
 
     def test_unary_callable_unary(self):
-        dataset = tabular.from_data(('a', lambda i: i * i), size=10)
+        dataset = tabular.from_data(('key_a', lambda i: i * i), size=10)
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
-        assert dataset.keys == ('a',)
+        assert dataset.keys == ('key_a',)
         assert(dataset.mode) is None
 
         output = dataset.slice[[1, 3]].fetch()
@@ -69,11 +69,11 @@ class TestFromData:
 
     def test_unary_callable_tuple(self):
         dataset = tabular.from_data(
-            (('a', 'b'), lambda i: (i * i, -i)), size=10)
+            (('key_a', 'key_b'), lambda i: (i * i, -i)), size=10)
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
-        assert dataset.keys == ('a', 'b')
+        assert dataset.keys == ('key_a', 'key_b')
         assert dataset.mode == tuple
 
         output = dataset.slice[[1, 3]].fetch()
@@ -83,15 +83,15 @@ class TestFromData:
 
     def test_unary_callable_dict(self):
         dataset = tabular.from_data(
-            (('a', 'b'), lambda i: {'a': i * i, 'b': -i}), size=10)
+            (('key_a', 'key_b'), lambda i: {'key_a': i * i, 'key_b': -i}), size=10)
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
-        assert dataset.keys == ('a', 'b')
+        assert dataset.keys == ('key_a', 'key_b')
         assert dataset.mode == dict
 
         output = dataset.slice[[1, 3]].fetch()
-        np.testing.assert_equal(output, {'a': [1, 9], 'b': [-1, -3]})
+        np.testing.assert_equal(output, {'key_a': [1, 9], 'key_b': [-1, -3]})
         for out in output.values():
             assert isinstance(out, list)
 
@@ -101,7 +101,7 @@ class TestFromData:
 
     def test_unary_callable_without_size(self):
         with pytest.raises(ValueError):
-            tabular.from_data(('a', lambda i: i * i))
+            tabular.from_data(('key_a', lambda i: i * i))
 
     def test_tuple_array_list(self):
         dataset = tabular.from_data(
@@ -119,12 +119,12 @@ class TestFromData:
 
     def test_tuple_array_with_key_list(self):
         dataset = tabular.from_data(
-            (('a', np.arange(10)), [2, 7, 1, 8, 4, 5, 9, 0, 3, 6]))
+            (('key_a', np.arange(10)), [2, 7, 1, 8, 4, 5, 9, 0, 3, 6]))
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
         assert len(dataset.keys) == 2
-        assert dataset.keys[0] == 'a'
+        assert dataset.keys[0] == 'key_a'
         assert dataset.mode == tuple
 
         output = dataset.slice[[1, 3]].fetch()
@@ -134,12 +134,12 @@ class TestFromData:
 
     def test_tuple_array_list_with_key(self):
         dataset = tabular.from_data(
-            (np.arange(10), ('b', [2, 7, 1, 8, 4, 5, 9, 0, 3, 6])))
+            (np.arange(10), ('key_b', [2, 7, 1, 8, 4, 5, 9, 0, 3, 6])))
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
         assert len(dataset.keys) == 2
-        assert dataset.keys[1] == 'b'
+        assert dataset.keys[1] == 'key_b'
         assert dataset.mode == tuple
 
         output = dataset.slice[[1, 3]].fetch()
@@ -148,12 +148,12 @@ class TestFromData:
         assert isinstance(output[1], list)
 
     def test_tuple_array_callable_unary(self):
-        dataset = tabular.from_data((np.arange(10), ('b', lambda i: i * i)))
+        dataset = tabular.from_data((np.arange(10), ('key_b', lambda i: i * i)))
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
         assert len(dataset.keys) == 2
-        assert dataset.keys[1] == 'b'
+        assert dataset.keys[1] == 'key_b'
         assert dataset.mode == tuple
 
         output = dataset.slice[[1, 3]].fetch()
@@ -163,12 +163,12 @@ class TestFromData:
 
     def test_tuple_array_callable_tuple(self):
         dataset = tabular.from_data(
-            (np.arange(10), (('b', 'c'), lambda i: (i * i, -i))))
+            (np.arange(10), (('key_b', 'key_c'), lambda i: (i * i, -i))))
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
         assert len(dataset.keys) == 3
-        assert dataset.keys[1] == ('b')
+        assert dataset.keys[1] == ('key_b')
         assert dataset.mode == tuple
 
         output = dataset.slice[[1, 3]].fetch()
@@ -178,12 +178,12 @@ class TestFromData:
 
     def test_tuple_array_callable_dict(self):
         dataset = tabular.from_data(
-            (np.arange(10), (('b', 'c'), lambda i: {'b': i * i, 'c': -i})))
+            (np.arange(10), (('key_b', 'key_c'), lambda i: {'key_b': i * i, 'key_c': -i})))
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
         assert len(dataset.keys) == 3
-        assert dataset.keys[1] == ('b')
+        assert dataset.keys[1] == ('key_b')
         assert dataset.mode == tuple
 
         output = dataset.slice[[1, 3]].fetch()
@@ -193,11 +193,11 @@ class TestFromData:
 
     def test_tuple_array_with_key_callable_unary(self):
         dataset = tabular.from_data(
-            (('a', np.arange(10)), ('b', lambda i: i * i)))
+            (('key_a', np.arange(10)), ('key_b', lambda i: i * i)))
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
-        assert dataset.keys == ('a', 'b')
+        assert dataset.keys == ('key_a', 'key_b')
         assert dataset.mode == tuple
 
         output = dataset.slice[[1, 3]].fetch()
@@ -207,11 +207,11 @@ class TestFromData:
 
     def test_tuple_callable_unary_callable_unary(self):
         dataset = tabular.from_data(
-            (('a', lambda i: i * i), ('b', lambda i: -i)), size=10)
+            (('key_a', lambda i: i * i), ('key_b', lambda i: -i)), size=10)
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
-        assert dataset.keys == ('a', 'b')
+        assert dataset.keys == ('key_a', 'key_b')
         assert dataset.mode == tuple
 
         output = dataset.slice[[1, 3]].fetch()
@@ -221,83 +221,83 @@ class TestFromData:
 
     def test_tuple_callable_unary_callable_unary_without_size(self):
         with pytest.raises(ValueError):
-            tabular.from_data((('a', lambda i: i * i), ('b', lambda i: -i)))
+            tabular.from_data((('key_a', lambda i: i * i), ('key_b', lambda i: -i)))
 
     def test_dict_array_list(self):
         dataset = tabular.from_data(
-            {'a': np.arange(10), 'b': [2, 7, 1, 8, 4, 5, 9, 0, 3, 6]})
+            {'key_a': np.arange(10), 'key_b': [2, 7, 1, 8, 4, 5, 9, 0, 3, 6]})
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
-        assert set(dataset.keys) == {'a', 'b'}
+        assert set(dataset.keys) == {'key_a', 'key_b'}
         assert dataset.mode == dict
 
         output = dataset.slice[[1, 3]].fetch()
-        np.testing.assert_equal(output, {'a': [1, 3], 'b': [7, 8]})
-        assert isinstance(output['a'], np.ndarray)
-        assert isinstance(output['b'], list)
+        np.testing.assert_equal(output, {'key_a': [1, 3], 'key_b': [7, 8]})
+        assert isinstance(output['key_a'], np.ndarray)
+        assert isinstance(output['key_b'], list)
 
     def test_dict_array_callable_unary(self):
-        dataset = tabular.from_data({'a': np.arange(10), 'b': lambda i: i * i})
+        dataset = tabular.from_data({'key_a': np.arange(10), 'key_b': lambda i: i * i})
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
-        assert set(dataset.keys) == {'a', 'b'}
+        assert set(dataset.keys) == {'key_a', 'key_b'}
         assert dataset.mode == dict
 
         output = dataset.slice[[1, 3]].fetch()
-        np.testing.assert_equal(output, {'a': [1, 3], 'b': [1, 9]})
-        assert isinstance(output['a'], np.ndarray)
-        assert isinstance(output['b'], list)
+        np.testing.assert_equal(output, {'key_a': [1, 3], 'key_b': [1, 9]})
+        assert isinstance(output['key_a'], np.ndarray)
+        assert isinstance(output['key_b'], list)
 
     def test_dict_array_callable_tuple(self):
         dataset = tabular.from_data(
-            {'a': np.arange(10), ('b', 'c'): lambda i: (i * i, -i)})
+            {'key_a': np.arange(10), ('key_b', 'key_c'): lambda i: (i * i, -i)})
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
-        assert set(dataset.keys) == {'a', 'b', 'c'}
+        assert set(dataset.keys) == {'key_a', 'key_b', 'key_c'}
         assert dataset.mode == dict
 
         output = dataset.slice[[1, 3]].fetch()
         np.testing.assert_equal(
-            output, {'a': [1, 3], 'b': [1, 9], 'c': [-1, -3]})
-        assert isinstance(output['a'], np.ndarray)
-        assert isinstance(output['b'], list)
-        assert isinstance(output['c'], list)
+            output, {'key_a': [1, 3], 'key_b': [1, 9], 'key_c': [-1, -3]})
+        assert isinstance(output['key_a'], np.ndarray)
+        assert isinstance(output['key_b'], list)
+        assert isinstance(output['key_c'], list)
 
     def test_dict_array_callable_dict(self):
         dataset = tabular.from_data(
-            {'a': np.arange(10), ('b', 'c'): lambda i: {'b': i * i, 'c': -i}})
+            {'key_a': np.arange(10), ('key_b', 'key_c'): lambda i: {'key_b': i * i, 'key_c': -i}})
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
-        assert set(dataset.keys) == {'a', 'b', 'c'}
+        assert set(dataset.keys) == {'key_a', 'key_b', 'key_c'}
         assert dataset.mode == dict
 
         output = dataset.slice[[1, 3]].fetch()
         np.testing.assert_equal(
-            output, {'a': [1, 3], 'b': [1, 9], 'c': [-1, -3]})
-        assert isinstance(output['a'], np.ndarray)
-        assert isinstance(output['b'], list)
-        assert isinstance(output['c'], list)
+            output, {'key_a': [1, 3], 'key_b': [1, 9], 'key_c': [-1, -3]})
+        assert isinstance(output['key_a'], np.ndarray)
+        assert isinstance(output['key_b'], list)
+        assert isinstance(output['key_c'], list)
 
     def test_dict_callable_unary_callable_unary(self):
         dataset = tabular.from_data(
-            {'a': lambda i: i * i, 'b': lambda i: -i}, size=10)
+            {'key_a': lambda i: i * i, 'key_b': lambda i: -i}, size=10)
 
         assert isinstance(dataset, ppe.dataset.TabularDataset)
         assert len(dataset) == 10
-        assert set(dataset.keys) == {'a', 'b'}
+        assert set(dataset.keys) == {'key_a', 'key_b'}
 
         output = dataset.slice[[1, 3]].fetch()
-        np.testing.assert_equal(output, {'a': [1, 9], 'b': [-1, -3]})
-        assert isinstance(output['a'], list)
-        assert isinstance(output['b'], list)
+        np.testing.assert_equal(output, {'key_a': [1, 9], 'key_b': [-1, -3]})
+        assert isinstance(output['key_a'], list)
+        assert isinstance(output['key_b'], list)
 
     def test_dict_callable_unary_callable_unary_without_size(self):
         with pytest.raises(ValueError):
-            tabular.from_data(({'a': lambda i: i * i, 'b': lambda i: -i}))
+            tabular.from_data(({'key_a': lambda i: i * i, 'key_b': lambda i: -i}))
 
     def test_unique(self):
         dataset_a = tabular.from_data(np.arange(10))


### PR DESCRIPTION
Currently, `tabular.from_data` treats `key_a` as a tuple of characters. This must be a bug.