### PR TITLE
Update lazy docs (add link to upstreamed version)

### DIFF
--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -6,9 +6,14 @@ Following modules are provided:
 
 * `ppe.nn.LazyLinear`
     * Module that behaves as `torch.nn.Linear` but `in_features` can be set to `None`.
+    * This module is now included as a part of PyTorch 1.8 release ([torch.nn.LazyLinear](https://pytorch.org/docs/stable/generated/torch.nn.LazyLinear.html), [pull-request](https://github.com/pytorch/pytorch/pull/44538)]).
 
 * `ppe.nn.LazyConv1d`, `ppe.nn.LazyConv2d`, `ppe.nn.LazyConv3d`
     * Module that behaves as `torch.nn.Conv[123]d` but `in_channels` can be set to `None`.
+    * These modles are now included as a part of PyTorch 1.8 release ([torch.nn.LazyConvXd](https://pytorch.org/docs/stable/generated/torch.nn.LazyConv1d.html), [pull-request](https://github.com/pytorch/pytorch/pull/47350)]).
+
+* `ppe.nn.LazyBatchNorm1d`, `ppe.nn.LazyBatchNorm2d`, `ppe.nn.LazyBatchNorm3d`
+    * Module that behaves as `torch.nn.BatchNorm[123]d` but `num_features` can be set to `None`.
 
 Note that you need to run a "dummy" forward to initialize lazy parameters.
 See the example below:

--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -6,11 +6,11 @@ Following modules are provided:
 
 * `ppe.nn.LazyLinear`
     * Module that behaves as `torch.nn.Linear` but `in_features` can be set to `None`.
-    * This module is now included as a part of PyTorch 1.8 release ([torch.nn.LazyLinear](https://pytorch.org/docs/stable/generated/torch.nn.LazyLinear.html), [pull-request](https://github.com/pytorch/pytorch/pull/44538)]).
+    * This module is now included as a part of PyTorch 1.8 release ([torch.nn.LazyLinear](https://pytorch.org/docs/stable/generated/torch.nn.LazyLinear.html), [pull-request](https://github.com/pytorch/pytorch/pull/44538)).
 
 * `ppe.nn.LazyConv1d`, `ppe.nn.LazyConv2d`, `ppe.nn.LazyConv3d`
     * Module that behaves as `torch.nn.Conv[123]d` but `in_channels` can be set to `None`.
-    * These modles are now included as a part of PyTorch 1.8 release ([torch.nn.LazyConvXd](https://pytorch.org/docs/stable/generated/torch.nn.LazyConv1d.html), [pull-request](https://github.com/pytorch/pytorch/pull/47350)]).
+    * These modles are now included as a part of PyTorch 1.8 release ([torch.nn.LazyConvXd](https://pytorch.org/docs/stable/generated/torch.nn.LazyConv1d.html), [pull-request](https://github.com/pytorch/pytorch/pull/47350)).
 
 * `ppe.nn.LazyBatchNorm1d`, `ppe.nn.LazyBatchNorm2d`, `ppe.nn.LazyBatchNorm3d`
     * Module that behaves as `torch.nn.BatchNorm[123]d` but `num_features` can be set to `None`.


### PR DESCRIPTION
PyTorch 1.8 is out, and some Lazy modules are now part of the official PyTorch release!
This PR adds links to the upstream docs.

Also fixes the issue that LazyBatchNorm is not documented.
(FYI, it is already upstreamed and will be released as PyTorch 1.9. https://github.com/pytorch/pytorch/pull/51862)