### PR TITLE
Fix get_examples of _Transform/_TransformBatch

### DIFF
--- a/tests/pytorch_pfn_extras_tests/dataset_tests/tabular_tests/test_transform.py
+++ b/tests/pytorch_pfn_extras_tests/dataset_tests/tabular_tests/test_transform.py
@@ -25,7 +25,7 @@ def _filter_params(params):
          [tuple, dict, None],
          [tuple, dict, None],
          [None, [1, 3], slice(None, 2)],
-         [None, (0,), (1, 0)],
+         [None, (0,), (1,), (1, 0)],
          [False, True]))
 )
 def test_transform(in_mode, out_mode, indices, key_indices, with_batch):


### PR DESCRIPTION
When `get_examples` is called with discontinuous `key_indices`,  `_Transform/_TransformBatch` creates wrong mapping between the outputs of transform functions and the outputs of  `get_examples`.