### PR TITLE
Pass CUDA_VISIBLE_DEVICES when running CI

### DIFF
--- a/.flexci/linux/script.sh
+++ b/.flexci/linux/script.sh
@@ -30,6 +30,7 @@ main() {
   # Prepare docker args.
   docker_args=(
     docker run --rm --ipc=host --privileged --runtime=nvidia
+    --env CUDA_VISIBLE_DEVICES
     --volume="${SRC_ROOT}:/src"
     --workdir="/src"
   )


### PR DESCRIPTION
When running tests in local environment sometimes I want to pass CUDA_VISIBLE_DEVICES to filter devices not supported by PyTorch wheels (e.g. A100).