### PR TITLE
Fix minmax value trigger

### DIFF
--- a/pytorch_pfn_extras/training/triggers/minmax_value_trigger.py
+++ b/pytorch_pfn_extras/training/triggers/minmax_value_trigger.py
@@ -50,6 +50,11 @@ class BestValueTrigger:
             return False
 
         stats = summary.compute_mean()
+
+        # This is needed when using DDP as some process may not have this stat
+        if key not in stats:
+            return False
+
         value = float(stats[key])  # copy to CPU
         self._init_summary()
 

--- a/tests/pytorch_pfn_extras_tests/training_tests/triggers_tests/test_minmax_value_trigger.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/triggers_tests/test_minmax_value_trigger.py
@@ -94,3 +94,16 @@ def test_resumed_trigger(
     new_trigger.load_state_dict(state)
     _test_trigger(
         manager, new_trigger, key, accuracies[resume:], expected[resume:])
+
+
+def test_trigger_not_stats():
+    key = 'main/accuracy'
+    accuracies = [0.5, 0.5, 0.4, 0.6]
+    manager = training.ExtensionsManager(
+        {}, [], 100, iters_per_epoch=1)
+    trigger = triggers.MaxValueTrigger(key, (1, 'iteration'))
+
+    for accuracy in accuracies:
+        with manager.run_iteration():
+            manager.observation = {'dummy': accuracy}
+        assert not trigger(manager)


### PR DESCRIPTION
This causes errors when using DDP as some of the workers may not have the key in their stats.