### PR TITLE
Fix `append` option not supported in Writers other than SimpleWriter

### DIFF
--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot_writers.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot_writers.py
@@ -38,16 +38,20 @@ def test_thread_writer_create_worker():
     target = mock.MagicMock()
     w = writing.ThreadWriter()
     with tempfile.TemporaryDirectory() as tempd:
-        worker = w.create_worker('myfile.dat', tempd, target)
+        worker = w.create_worker('myfile.dat', tempd, target, append=False)
         assert isinstance(worker, threading.Thread)
+        w('myfile2.dat', tempd, 'test')
+        w.finalize()
 
 
 def test_process_writer_create_worker():
     target = mock.MagicMock()
     w = writing.ProcessWriter()
     with tempfile.TemporaryDirectory() as tempd:
-        worker = w.create_worker('myfile.dat', tempd, target)
+        worker = w.create_worker('myfile.dat', tempd, target, append=False)
         assert isinstance(worker, multiprocessing.Process)
+        w('myfile2.dat', tempd, 'test')
+        w.finalize()
 
 
 def test_queue_writer():


### PR DESCRIPTION
This PR fixes the incompatibility between `TensorBoardWriter` and `LogReport` extension (thanks @HiroakiMikami for reporting!)

```py
writer = ppe.writing.TensorBoardWriter(out_dir=log_dir)
manager.extend(ppe.training.extensions.LogReport(writer=writer, trigger=(1, "iteration")))
```

This was a regression in #118.