### PR TITLE
Fix to finalize TensorBoardWriter

### DIFF
--- a/pytorch_pfn_extras/writing.py
+++ b/pytorch_pfn_extras/writing.py
@@ -529,6 +529,9 @@ class TensorBoardWriter(object):
         self._writer = torch.utils.tensorboard.SummaryWriter(
             log_dir=out_dir, **kwds)
 
+    def __del__(self):
+        self.finalize()
+
     def __call__(
             self, filename, out_dir, target, *, savefun=None, append=False):
         """Sends the statistics to the TensorBoard.
@@ -554,3 +557,6 @@ class TensorBoardWriter(object):
         for key in keys:
             value = stats_cpu[key]
             self._writer.add_scalar(key, value, stats_cpu['iteration'])
+
+    def finalize(self):
+        self._writer.close()

--- a/tests/pytorch_pfn_extras_tests/test_writing.py
+++ b/tests/pytorch_pfn_extras_tests/test_writing.py
@@ -16,5 +16,3 @@ def test_tensorboard_writing():
         # Check that the file was generated
         for snap in os.listdir(tempd):
             assert '_test' in snap
-        writer._writer.flush()
-        writer._writer.close()

--- a/tests/pytorch_pfn_extras_tests/test_writing.py
+++ b/tests/pytorch_pfn_extras_tests/test_writing.py
@@ -16,3 +16,4 @@ def test_tensorboard_writing():
         # Check that the file was generated
         for snap in os.listdir(tempd):
             assert '_test' in snap
+        writer.finalize()

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_log_report.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_log_report.py
@@ -63,3 +63,35 @@ def test_output(format, append):
                 assert (this_epoch['iteration']
                         == (epoch_idx + 1) * iters_per_epoch)
                 assert 0 < this_epoch['elapsed_time']
+
+
+def test_tensorboard_writer():
+    pytest.importorskip('tensorboard')
+
+    max_epochs = 3
+    iters_per_epoch = 5
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        writer = ppe.writing.TensorBoardWriter(out_dir=tmpdir)
+        log_report = extensions.LogReport(
+            writer=writer, trigger=(1, 'iteration'))
+        manager = ppe.training.ExtensionsManager(
+            {}, {}, max_epochs=max_epochs, iters_per_epoch=iters_per_epoch,
+            out_dir=tmpdir)
+        manager.extend(log_report)
+        for epoch_idx in range(max_epochs):
+            for batch_idx in range(iters_per_epoch):
+                with manager.run_iteration():
+                    pass
+        writer.finalize()
+
+        files = os.listdir(tmpdir)
+        assert len(files) == 1
+        tb_file = files[0]
+        assert tb_file.startswith('events.out.')
+
+        # Won't play with protobuf, just ensure that our keys are in.
+        with open(os.path.join(tmpdir, tb_file), 'rb') as f:
+            tb_data = f.read()
+        for key in ['epoch', 'iteration', 'elapsed_time']:
+            assert key.encode('ascii') in tb_data


### PR DESCRIPTION
TensorBoard's SummaryWriter must be finalized, but it was not.

This PR walso adds LogReport & TensorBoardWriter use-case test (c.f., #156).