### PR TITLE
Fix TensorBoard to no-op if TensorBoard is unavailable

### DIFF
--- a/example/mnist.py
+++ b/example/mnist.py
@@ -118,7 +118,7 @@ def main():
         # Enables TensorBoard support.
         # Run `tensorboard --logdir runs` to launch the TensorBoard.
         extensions.LogReport(
-            writer=ppe.writing.TensorBoardWriter('runs'),
+            writer=ppe.writing.TensorBoardWriter(out_dir='runs'),
             trigger=(1, 'iteration')),
         extensions.ProgressBar(),
         extensions.observe_lr(optimizer=optimizer),

--- a/example/mnist.py
+++ b/example/mnist.py
@@ -114,6 +114,12 @@ def main():
     # manager.extend(...) also works
     my_extensions = [
         extensions.LogReport(),
+
+        # Enables TensorBoard support.
+        # Run `tensorboard --logdir runs` to launch the TensorBoard.
+        extensions.LogReport(
+            writer=ppe.writing.TensorBoardWriter('runs'),
+            trigger=(1, 'iteration')),
         extensions.ProgressBar(),
         extensions.observe_lr(optimizer=optimizer),
         extensions.ParameterStatistics(model, prefix='model'),

--- a/pytorch_pfn_extras/training/extensions/log_report.py
+++ b/pytorch_pfn_extras/training/extensions/log_report.py
@@ -263,5 +263,5 @@ class LogReport(extension.Extension):
         return pandas.DataFrame(self._log_looker.get())
 
     def finalize(self) -> None:
-        if self._writer is not None:
+        if self._writer is not None and hasattr(self._writer, 'finalize'):
             self._writer.finalize()

--- a/pytorch_pfn_extras/training/extensions/log_report.py
+++ b/pytorch_pfn_extras/training/extensions/log_report.py
@@ -263,5 +263,5 @@ class LogReport(extension.Extension):
         return pandas.DataFrame(self._log_looker.get())
 
     def finalize(self) -> None:
-        if self._writer is not None and hasattr(self._writer, 'finalize'):
+        if self._writer is not None:
             self._writer.finalize()

--- a/pytorch_pfn_extras/writing/_tensorboard_writer.py
+++ b/pytorch_pfn_extras/writing/_tensorboard_writer.py
@@ -1,4 +1,5 @@
 from typing import Any, KeysView, Optional
+import warnings
 
 from pytorch_pfn_extras.writing._writer_base import (
     _TargetType, _SaveFun, _FileSystem
@@ -27,10 +28,17 @@ class TensorBoardWriter(object):
             stats: Optional[KeysView[str]] = None,
             **kwds: Any
     ) -> None:
-        from torch.utils.tensorboard import SummaryWriter
+        self._writer = None
+        try:
+            import torch.utils.tensorboard
+        except ImportError:
+            warnings.warn(
+                'tensorboard is unavailable. '
+                'TensorBoardWriter will do nothing.')
+            return
         self._stats = stats
-        self._writer: Optional[SummaryWriter] = (
-            SummaryWriter(  # type: ignore[no-untyped-call]
+        self._writer: Optional[torch.utils.tensorboard.SummaryWriter] = (
+            torch.utils.tensorboard.SummaryWriter(  # type: ignore[no-untyped-call]
                 log_dir=out_dir, **kwds))
 
     def __del__(self) -> None:
@@ -57,8 +65,7 @@ class TensorBoardWriter(object):
             append: Ignored.
         """
         if self._writer is None:
-            raise RuntimeError('TensorBoardWriter already finalized')
-
+            return
         stats_cpu = target
         if isinstance(target, list):
             stats_cpu = target[-1]
@@ -74,7 +81,6 @@ class TensorBoardWriter(object):
                 key, value, stats_cpu['iteration'])
 
     def finalize(self) -> None:
-        writer = self._writer
-        if writer is not None:
-            writer.close()  # type: ignore[no-untyped-call]
+        if self._writer is not None:
+            self._writer.close()  # type: ignore[no-untyped-call]
         self._writer = None

--- a/pytorch_pfn_extras/writing/_tensorboard_writer.py
+++ b/pytorch_pfn_extras/writing/_tensorboard_writer.py
@@ -83,4 +83,4 @@ class TensorBoardWriter(object):
     def finalize(self) -> None:
         if self._writer is not None:
             self._writer.close()  # type: ignore[no-untyped-call]
-        self._writer = None
+            self._writer = None

--- a/pytorch_pfn_extras/writing/_tensorboard_writer.py
+++ b/pytorch_pfn_extras/writing/_tensorboard_writer.py
@@ -37,7 +37,7 @@ class TensorBoardWriter(object):
                 'TensorBoardWriter will do nothing.')
             return
         self._stats = stats
-        self._writer: Optional[torch.utils.tensorboard.SummaryWriter] = (
+        self._writer = (
             torch.utils.tensorboard.SummaryWriter(  # type: ignore[no-untyped-call]
                 log_dir=out_dir, **kwds))
 


### PR DESCRIPTION
Closes #155. ~Depends on #158~ (merged).
I think this is better when reusing experiment codes.