### PR TITLE
Fix timer function

### DIFF
--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -1,7 +1,6 @@
 import collections
 import contextlib
 import copy
-import os
 import time
 import warnings
 

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -13,14 +13,8 @@ from pytorch_pfn_extras.training import extension as extension_module
 from pytorch_pfn_extras.training import trigger as trigger_module
 from pytorch_pfn_extras.training import util as util_module
 
-# Select the best-resolution timer function
-try:
-    _get_time = time.perf_counter
-except AttributeError:
-    if os.name == 'nt':
-        _get_time = time.clock
-    else:
-        _get_time = time.time
+
+_get_time = time.perf_counter
 
 
 class _ExtensionEntry:


### PR DESCRIPTION
`time.perf_counter` is added in Python 3.3 so we can now assume it's always available.
https://docs.python.org/3.6/library/time.html#time.perf_counter

Also note that `time.clock` is removed in Python 3.8.