### PR TITLE
Fix print in `_PosixFileSystem.rename`

### DIFF
--- a/pytorch_pfn_extras/writing.py
+++ b/pytorch_pfn_extras/writing.py
@@ -119,7 +119,7 @@ class _PosixFileSystem(object):
             return os.replace(src, dst)
         except OSError:
             print('Destination {} is a directory '
-                  'but source is not'.format(src),
+                  'but source is not'.format(dst),
                   file=sys.stderr)
             raise
 


### PR DESCRIPTION
Fixes a print message in `_PosixFileSystem.rename` which could be a bit confusing.