### PR TITLE
Improve handling of backup files

### DIFF
--- a/pytorch_pfn_extras/writing.py
+++ b/pytorch_pfn_extras/writing.py
@@ -220,7 +220,7 @@ class Writer:
             if make_backup:
                 bak = '{}.bak'.format(dest)
                 # Check if another backup file exists
-                # due to some unexpected termination of an older
+                # due to some unexpected termination of an earlier
                 # process
                 if self.fs.exists(bak):
                     self.fs.remove(bak)

--- a/pytorch_pfn_extras/writing.py
+++ b/pytorch_pfn_extras/writing.py
@@ -215,6 +215,8 @@ class Writer:
             prefix = 'tmp_{}'.format(filename)
             tmppath = os.path.join(out_dir, prefix)
             make_backup = self.fs.exists(dest)
+            with self.fs.open(tmppath, 'wb') as f:
+                savefun(target, f, **savefun_kwargs)
             if make_backup:
                 bak = '{}.bak'.format(dest)
                 # Check if another backup file exists
@@ -223,8 +225,6 @@ class Writer:
                 if self.fs.exists(bak):
                     self.fs.remove(bak)
                 self.fs.rename(dest, bak)
-            with self.fs.open(tmppath, 'wb') as f:
-                savefun(target, f, **savefun_kwargs)
             self.fs.rename(tmppath, dest)
             if make_backup:
                 self.fs.remove(bak)

--- a/pytorch_pfn_extras/writing.py
+++ b/pytorch_pfn_extras/writing.py
@@ -217,6 +217,11 @@ class Writer:
             make_backup = self.fs.exists(dest)
             if make_backup:
                 bak = '{}.bak'.format(dest)
+                # Check if another backup file exists
+                # due to some unexpected termination of an older
+                # process
+                if self.fs.exists(bak):
+                    self.fs.remove(bak)
                 self.fs.rename(dest, bak)
             with self.fs.open(tmppath, 'wb') as f:
                 savefun(target, f, **savefun_kwargs)


### PR DESCRIPTION
This is to partly fix the issue in #168 
Some unexpected process termination can leave a '.bak' file undelete, so next executions will error.