### PR TITLE
Fix LazyModules load_hook

### DIFF
--- a/pytorch_pfn_extras/nn/modules/lazy.py
+++ b/pytorch_pfn_extras/nn/modules/lazy.py
@@ -93,20 +93,8 @@ class LazyInitializationMixin:
         for the details of the hook specification.
         """
         for name in self.lazy_buffer_names:
-            # Avoid shape mismatch error when loading an initialized buffer
-            # onto an uninitialized module instance.
             key = prefix + name
-            if key in state_dict:
-                # The model was serialized after initialization.
-                if getattr(self, name).shape == (0,):
-                    raise RuntimeError(
-                        'Can\'t load an already initialized '
-                        'buffer into a non initialized one')
-            else:
-                if getattr(self, name).shape != (0,):
-                    raise RuntimeError(
-                        'Can\'t replace a already initialized '
-                        'buffer with a non initialized one')
+            if key not in state_dict:
                 buffer = torch.Tensor([])
                 state_dict[key] = buffer
 

--- a/pytorch_pfn_extras/nn/modules/lazy.py
+++ b/pytorch_pfn_extras/nn/modules/lazy.py
@@ -91,14 +91,13 @@ class LazyInitializationMixin:
         for name in self.lazy_buffer_names:
             key = prefix + name
             module_initialized = getattr(self, name).shape != (0,)
-            state_initialized = (
-                 key in state_dict and (state_dict[key].shape != (0,)))
+            state_initialized = state_dict[key].shape != (0,)
             if module_initialized and not state_initialized:
                 raise RuntimeError(
                     'Can\'t load non-initialized buffers in already '
                     'initialized modules')
             elif not module_initialized and state_initialized:
-                # Here we need to avoid a tensor size missmatch
+                # Here we need to avoid a tensor size mismatch
                 # this is a regular tensor without a materialize
                 # method, so we can just resize for the load logic to copy
                 # the contents later to the correct device the module

--- a/pytorch_pfn_extras/nn/modules/lazy.py
+++ b/pytorch_pfn_extras/nn/modules/lazy.py
@@ -88,6 +88,26 @@ class LazyInitializationMixin:
         See comment in ``torch.nn.Module._register_load_state_dict_pre_hook``
         for the details of the hook specification.
         """
+        for name in self.lazy_buffer_names:
+            key = prefix + name
+            module_initialized = getattr(self, name).shape != (0,)
+            state_initialized = (
+                 key in state_dict and (state_dict[key].shape != (0,)))
+            if module_initialized and not state_initialized:
+                raise RuntimeError(
+                    'Can\'t load non-initialized buffers in already '
+                    'initialized modules')
+            elif not module_initialized and state_initialized:
+                # Here we need to avoid a tensor size missmatch
+                # this is a regular tensor without a materialize
+                # method, so we can just resize for the load logic to copy
+                # the contents later to the correct device the module
+                # was moved to
+                getattr(self, name).resize_(state_dict[key].size())
+            elif key not in state_dict and not module_initialized:
+                buffer = torch.Tensor([])
+                state_dict[key] = buffer
+
         for name in self.lazy_parameter_names:
             # The parameter does not exist in the loaded ``state_dict`` if the
             # original module was serialized before initializing lazy
@@ -100,6 +120,8 @@ class LazyInitializationMixin:
                 raise RuntimeError(
                     'Can\'t load uninitialized parameters in already '
                     'initialized modules')
+            elif not module_initialized and state_initialized:
+                getattr(self, name).materialize(state_dict[key].shape)
             elif key not in state_dict and not module_initialized:
                 param = UninitializedParameter()
                 state_dict[key] = param
@@ -128,3 +150,25 @@ class UninitializedParameter(torch.nn.Parameter):
     Use of uninitialized lazy parameter in Optimizer has been detected.
     Maybe you forgot to run forward before passing `module.parameters()` to the optimizer?''')  # NOQA
         return True
+
+    def materialize(self, shape, device=None, dtype=None):
+        r"""Create a Parameter with the same properties of the uninitialized
+        one. Given a shape, it materializes a parameter in the same device
+        and with the same `dtype` as the current one or the specified ones in
+        the arguments.
+
+        Args:
+            shape : (tuple): the shape for the materialized tensor.
+            device (:class:`torch.device`): the desired device of the
+                parameters
+                and buffers in this module. Optional.
+            dtype (:class:`torch.dtype`): the desired floating point type of
+                the floating point parameters and buffers in this module.
+                Optional.
+        """
+        if device is None:
+            device = self.data.device
+        if dtype is None:
+            dtype = self.data.dtype
+        self.data = torch.empty(shape, device=device, dtype=dtype)
+        self.__class__ = torch.nn.Parameter

--- a/pytorch_pfn_extras/nn/modules/lazy.py
+++ b/pytorch_pfn_extras/nn/modules/lazy.py
@@ -104,9 +104,6 @@ class LazyInitializationMixin:
                 # the contents later to the correct device the module
                 # was moved to
                 getattr(self, name).resize_(state_dict[key].size())
-            elif key not in state_dict and not module_initialized:
-                buffer = torch.Tensor([])
-                state_dict[key] = buffer
 
         for name in self.lazy_parameter_names:
             # The parameter does not exist in the loaded ``state_dict`` if the

--- a/pytorch_pfn_extras/nn/modules/lazy.py
+++ b/pytorch_pfn_extras/nn/modules/lazy.py
@@ -101,8 +101,8 @@ class LazyInitializationMixin:
             key = prefix + name
             if key in state_dict:
                 # The model was serialized after initialization.
-                self.register_parameter(
-                    name, torch.nn.Parameter(state_dict[key]))
+                if isinstance(getattr(self, name), UninitializedParameter):
+                    raise RuntimeError('Cant load an uninitialized parameter')
             else:
                 # The model was serialized before initialization.
                 param = UninitializedParameter()

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py
@@ -136,17 +136,42 @@ class LazyTestBase:
         input = self.get_input()
         model_src = self.get_lazy_module()
         model_dst = self.get_lazy_module()
-
         if init_src:
             torch.manual_seed(0)
             model_src(input)
+
         if init_dst:
             torch.manual_seed(0)
             model_dst(input)
+            module_params = [
+                getattr(model_dst, name)
+                for name in model_dst.lazy_parameter_names
+            ]
+            module_buffers = [
+                getattr(model_dst, name)
+                for name in model_dst.lazy_buffer_names
+            ]
 
         with tempfile.NamedTemporaryFile(delete=False) as f:
             torch.save(model_src.state_dict(), f.name)
-            model_dst.load_state_dict(torch.load(f.name))
+            if (not init_dst and init_src) or (init_dst and not init_src):
+                with pytest.raises(RuntimeError):
+                    model_dst.load_state_dict(torch.load(f.name))
+            else:
+                model_dst.load_state_dict(torch.load(f.name))
+            print(torch.load(f.name))
+
+        # Ensure that if the model was initialized, the parameters are the same
+        # after loading a state dict
+        if init_dst:
+            for name, param in zip(
+                model_dst.lazy_parameter_names, module_params
+            ):
+                assert getattr(model_dst, name).data_ptr() == param.data_ptr()
+            for name, buffer in zip(
+                model_dst.lazy_buffer_names, module_buffers
+            ):
+                assert getattr(model_dst, name).data_ptr() == buffer.data_ptr()
 
         torch.manual_seed(0)
         expected = model_src(input)

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py
@@ -154,12 +154,11 @@ class LazyTestBase:
 
         with tempfile.NamedTemporaryFile(delete=False) as f:
             torch.save(model_src.state_dict(), f.name)
-            if init_src != init_dst:
+            if not init_src and init_dst:
                 with pytest.raises(RuntimeError):
                     model_dst.load_state_dict(torch.load(f.name))
             else:
                 model_dst.load_state_dict(torch.load(f.name))
-            print(torch.load(f.name))
 
         # Ensure that if the model was initialized, the parameters are the same
         # after loading a state dict

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py
@@ -154,7 +154,7 @@ class LazyTestBase:
 
         with tempfile.NamedTemporaryFile(delete=False) as f:
             torch.save(model_src.state_dict(), f.name)
-            if (not init_dst and init_src) or (init_dst and not init_src):
+            if init_src != init_dst:
                 with pytest.raises(RuntimeError):
                     model_dst.load_state_dict(torch.load(f.name))
             else:


### PR DESCRIPTION
Fixes #167 

We should be more careful and avoid weird cases of replacing existing parameters with non-existing ones, so we avoid recreating model parameters in the `load_state` dict which can lead to the new parameters not being tracked by the optimizer.

Torch lazy modules forbid mixing non-initialized params with initialized ones.