### PR TITLE
Make Extension typed

### DIFF
--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -54,7 +54,7 @@ class _BaseExtensionsManager:
             models: Union[torch.nn.Module, Dict[str, torch.nn.Module]],
             optimizers: Union[torch.optim.Optimizer, Dict[str, torch.optim.Optimizer]],
             max_epochs: int,
-            extensions: Optional[List[extension_module.ExtensionLike]],
+            extensions: Optional[List['extension_module.ExtensionLike']],
             out_dir: str,
             writer: Optional[writing.Writer],
             stop_trigger: 'trigger_module.TriggerLike' = None
@@ -217,7 +217,7 @@ class _BaseExtensionsManager:
 
     def extend(
             self,
-            extension: extension_module.ExtensionLike,
+            extension: 'extension_module.ExtensionLike',
             name: Optional[str] = None,
             trigger: 'trigger_module.TriggerLike' = None,
             priority: Optional[int] = None,
@@ -425,7 +425,7 @@ class ExtensionsManager(_BaseExtensionsManager):
             max_epochs: int,
             *,
             iters_per_epoch: Optional[int],
-            extensions: Optional[List[extension_module.ExtensionLike]] = None,
+            extensions: Optional[List['extension_module.ExtensionLike']] = None,
             out_dir: str = 'result',
             stop_trigger: 'trigger_module.TriggerLike' = None,
             writer: Optional[writing.Writer] = None
@@ -504,7 +504,7 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
             optimizers: Union[torch.optim.Optimizer, Dict[str, torch.optim.Optimizer]],
             max_epochs: int,
             *,
-            extensions: Optional[List[extension_module.ExtensionLike]] = None,
+            extensions: Optional[List['extension_module.ExtensionLike']] = None,
             out_dir: str = 'result',
             writer: Optional[writing.Writer] = None
     ) -> None:

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -54,7 +54,7 @@ class _BaseExtensionsManager:
             models: Union[torch.nn.Module, Dict[str, torch.nn.Module]],
             optimizers: Union[torch.optim.Optimizer, Dict[str, torch.optim.Optimizer]],
             max_epochs: int,
-            extensions: Optional[List[extension_module.Extension]],
+            extensions: Optional[List[extension_module.ExtensionLike]],
             out_dir: str,
             writer: Optional[writing.Writer],
             stop_trigger: 'trigger_module.TriggerLike' = None
@@ -217,7 +217,7 @@ class _BaseExtensionsManager:
 
     def extend(
             self,
-            extension: Callable[['_BaseExtensionsManager'], None],
+            extension: extension_module.ExtensionLike,
             name: Optional[str] = None,
             trigger: 'trigger_module.TriggerLike' = None,
             priority: Optional[int] = None,
@@ -425,7 +425,7 @@ class ExtensionsManager(_BaseExtensionsManager):
             max_epochs: int,
             *,
             iters_per_epoch: Optional[int],
-            extensions: Optional[List[extension_module.Extension]] = None,
+            extensions: Optional[List[extension_module.ExtensionLike]] = None,
             out_dir: str = 'result',
             stop_trigger: 'trigger_module.TriggerLike' = None,
             writer: Optional[writing.Writer] = None
@@ -504,7 +504,7 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
             optimizers: Union[torch.optim.Optimizer, Dict[str, torch.optim.Optimizer]],
             max_epochs: int,
             *,
-            extensions: Optional[List[extension_module.Extension]] = None,
+            extensions: Optional[List[extension_module.ExtensionLike]] = None,
             out_dir: str = 'result',
             writer: Optional[writing.Writer] = None
     ) -> None:


### PR DESCRIPTION
Depends on #179.

TODO: Remaining errors
```
pytorch_pfn_extras/training/extension.py:183: error: Property "default_name" defined in "Extension" is read-only  [misc]
pytorch_pfn_extras/training/extension.py:185: error: Cannot assign to a method  [assignment]
pytorch_pfn_extras/training/extension.py:185: error: Incompatible types in assignment (expression has type "Optional[Callable[[], None]]", variable has type "Callable[[], None]")  [assignment]
pytorch_pfn_extras/training/extension.py:186: error: Cannot assign to a method  [assignment]
pytorch_pfn_extras/training/extension.py:186: error: Incompatible types in assignment (expression has type "Optional[Callable[[ExtensionsManager, Exception, TracebackType], None]]", variable has type "Callable[[ExtensionsManager, Exception, TracebackType], None]")  [assignment]
pytorch_pfn_extras/training/extension.py:187: error: Cannot assign to a method  [assignment]
pytorch_pfn_extras/training/extension.py:187: error: Incompatible types in assignment (expression has type "Optional[Callable[[ExtensionsManager], None]]", variable has type "Callable[[ExtensionsManager], None]")  [assignment]
```