### PR TITLE
[ONNX] Support annotated models but run without export

### DIFF
--- a/pytorch_pfn_extras/onnx/annotate.py
+++ b/pytorch_pfn_extras/onnx/annotate.py
@@ -1,8 +1,10 @@
+import contextlib
 import functools
 
 import onnx.helper
 import torch
 import torch.nn as nn
+import torch.onnx
 import torch.onnx.symbolic_registry as sym_reg
 
 
@@ -191,7 +193,9 @@ def annotate(**attrs):
     Args:
         attrs (dict): annotation parameters
     """
-    return _Annotation(**attrs)
+    if torch.onnx.is_in_onnx_export():
+        return _Annotation(**attrs)
+    return contextlib.nullcontext()
 
 
 def apply_annotation(fn, *args, **attrs):
@@ -364,4 +368,6 @@ def scoped_anchor(**attrs):
     Args:
         attrs (dict): annotation parameters
     """
-    return _Anchor(**attrs)
+    if torch.onnx.is_in_onnx_export():
+        return _Anchor(**attrs)
+    return contextlib.nullcontext()

--- a/tests/pytorch_pfn_extras_tests/onnx/test_annotate.py
+++ b/tests/pytorch_pfn_extras_tests/onnx/test_annotate.py
@@ -22,7 +22,6 @@ from tests.pytorch_pfn_extras_tests.onnx.test_export_testcase import _helper
 torch_version = version.Version(torch.__version__)
 
 
-
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_annotate_no_export():
     if torch_version < version.Version('1.8.0'):

--- a/tests/pytorch_pfn_extras_tests/onnx/test_annotate.py
+++ b/tests/pytorch_pfn_extras_tests/onnx/test_annotate.py
@@ -22,6 +22,30 @@ from tests.pytorch_pfn_extras_tests.onnx.test_export_testcase import _helper
 torch_version = version.Version(torch.__version__)
 
 
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_annotate_no_export():
+    if torch_version < version.Version('1.8.0'):
+        pytest.skip('skip for PyTorch 1.7 or earlier')
+
+    class Net(nn.Module):
+        def __init__(self):
+            super(Net, self).__init__()
+            self.conv = nn.Conv2d(1, 6, 3)
+            self.linear = nn.Linear(30, 20, bias=False)
+
+        def forward(self, x):
+            with annotate(aaa='a'):
+                h = self.conv(x)
+            h = self.linear(h)
+            return h
+
+    model = Net()
+    x = torch.ones((1, 1, 32, 32))
+    y = model(x)
+    assert y.shape == (1, 6, 30, 20)
+
+
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_annotate():
     if torch_version < version.Version('1.8.0'):
@@ -151,6 +175,26 @@ def test_apply_annotation():
     assert 'yyy' in node_attrs
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_scoped_anchor_no_export():
+    class Net(nn.Module):
+        def __init__(self):
+            super(Net, self).__init__()
+            self.conv = nn.Conv2d(1, 6, 3)
+            self.linear = nn.Linear(30, 20, bias=False)
+
+        def forward(self, x):
+            h = self.conv(x)
+            with scoped_anchor(aaa='a'):
+                h = self.linear(h)
+            return h
+
+    model = Net()
+    x = torch.ones((1, 1, 32, 32))
+    y = model(x)
+    assert y.shape == (1, 6, 30, 20)
+
+
 @pytest.mark.filterwarnings(
     "ignore::torch.jit.TracerWarning",
     "ignore:floor_divide is deprecated:UserWarning",
@@ -160,6 +204,7 @@ def test_scoped_anchor():
     class Net(nn.Module):
         def __init__(self, anchor_mode='on'):
             super(Net, self).__init__()
+            self.anchor_mode = anchor_mode
 
             self.conv = nn.Conv2d(6, 9, 3)
             self.conv2 = nn.Conv2d(9, 12, 3)
@@ -180,10 +225,12 @@ def test_scoped_anchor():
             nn.init.constant_(self.linear3.weight, 0.1)
             nn.init.constant_(self.linear3.bias, 0.1)
 
-            if anchor_mode == 'on':
+        def set_anchor(self):
+            # required to setup in forwarding phase
+            if self.anchor_mode == 'on':
                 self.anchor1 = scoped_anchor(aaa='a', bbb=['b', 'c'])
                 self.anchor2 = scoped_anchor(ccc=[1, 2])
-            elif anchor_mode == 'no_param':
+            elif self.anchor_mode == 'no_param':
                 self.anchor1 = scoped_anchor()
                 self.anchor2 = scoped_anchor()
             else:
@@ -191,6 +238,7 @@ def test_scoped_anchor():
                 self.anchor2 = suppress()
 
         def forward(self, x):
+            self.set_anchor()
             h = self.conv(x)
             with self.anchor1:
                 h = self.conv2(h)


### PR DESCRIPTION
The model has `annotate` (or `anchor`) but run the model no under `ppe.onnx.export`, occurs an error.

```
>       for name, child_module in _annotation_init.model.named_children():
E       AttributeError: '_AnnotationInit' object has no attribute 'model'
```

This PR fix the error. `annotate` works only when `onnx.export` mode.