### PR TITLE
PlotReport: close plot when data is not set

### DIFF
--- a/pytorch_pfn_extras/training/extensions/plot_report.py
+++ b/pytorch_pfn_extras/training/extensions/plot_report.py
@@ -196,6 +196,11 @@ filename='plot.png', marker='x', grid=True)
                     bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
                 writer(self._file_name, manager.out, (f, leg, plt),
                        savefun=matplotlib_savefun)
+            else:
+                print(f"[WARNING] No data found for key {self._y_keys}, {self._file_name} not written.")
+                # Finalize figure
+                f.clf()
+                plt.close(f)
 
             self._init_summary()
 

--- a/pytorch_pfn_extras/training/extensions/plot_report.py
+++ b/pytorch_pfn_extras/training/extensions/plot_report.py
@@ -197,7 +197,10 @@ filename='plot.png', marker='x', grid=True)
                 writer(self._file_name, manager.out, (f, leg, plt),
                        savefun=matplotlib_savefun)
             else:
-                print(f"[WARNING] No data found for key {self._y_keys}, {self._file_name} not written.")
+                print(
+                    f"[WARNING] No data found for key {self._y_keys}, "
+                    f"{self._file_name} not written."
+                )
                 # Finalize figure
                 f.clf()
                 plt.close(f)

--- a/pytorch_pfn_extras/training/extensions/plot_report.py
+++ b/pytorch_pfn_extras/training/extensions/plot_report.py
@@ -13,7 +13,8 @@ _available = None
 def matplotlib_savefun(target, file_o):
     fig, leg, plt = target
     fig.savefig(file_o, bbox_extra_artists=(leg,), bbox_inches='tight')
-    plt.close()
+    fig.clf()
+    plt.close(fig)
 
 
 def _try_import_matplotlib():

--- a/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
+++ b/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
@@ -19,7 +19,8 @@ def percentile(a, q, axis):
 def matplotlib_savefun(target, file_o):
     fig, plt = target
     fig.savefig(file_o)
-    plt.close()
+    fig.clf()
+    plt.close(fig)
 
 
 def _try_import_matplotlib():


### PR DESCRIPTION
[close plot when data is not set]
when `a.has_data()` is false at PlotReport, it does not call `savefun` and it does not close figure instance `f`.
it causes to show warning, so I added code to close it even when a.has_data is False.

[thread safe close for matpltlib figure]

I think `plt.close()` may close other `fig` instance, if matplotlib is called in other thread/process. Explicitly close `fig` instance may be safer.

Also, I added to call `clf` method, to explicitly clear for better memory usage.
 - https://qiita.com/Masahiro_T/items/bdd0482a8efd84cdd270

