### PR TITLE
Fix dead links on README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Optional dependencies:
 
 ## Documentation
 
-* [Extensions Manager](docs/extensions.md)
-* [Reporting](docs/reporting.md)
-* [Lazy Modules](docs/lazy.md)
-* [Distributed Snapshot](docs/snapshot.md)
-* [Config System](docs/config.md)
-* [ONNX Utils](docs/onnx.md)
-* [CUDA Utils (CuPy Interoperability)](docs/cuda.md)
+* [Extensions Manager](docs/source/user_guide/extensions.md)
+* [Reporting](docs/source/user_guide/reporting.md)
+* [Lazy Modules](docs/source/user_guide/lazy.md)
+* [Distributed Snapshot](docs/source/user_guide/snapshot.md)
+* [Config System](docs/source/user_guide/config.md)
+* [ONNX Utils](docs/source/user_guide/onnx.md)
+* [CUDA Utils (CuPy Interoperability)](docs/source/user_guide/cuda.md)
 
 ## Examples
 


### PR DESCRIPTION
I'm trying to test this library and looked at the README.md, but it seems that all the links in the documentation section of README.md are dead links.
Looking at the history, it looks like a simple omission, so I fixed it.
