### PR TITLE
Show name of the Evaluator in its progress bar (default="validation", which is the current behavior)

### DIFF
--- a/pytorch_pfn_extras/training/extensions/evaluator.py
+++ b/pytorch_pfn_extras/training/extensions/evaluator.py
@@ -193,7 +193,8 @@ class Evaluator(extension.Extension):
 
         progress = IterationStatus(len(iterator))
         if self._progress_bar:
-            pbar = _IteratorProgressBar(iterator=progress)
+            name = self.name or self.default_name
+            pbar = _IteratorProgressBar(name=name, iterator=progress)
 
         last_iter = len(iterator) - 1
         with _in_eval_mode(self._targets.values()):
@@ -257,12 +258,13 @@ class IterationStatus:
 
 class _IteratorProgressBar(util.ProgressBar):
 
-    def __init__(self, iterator, bar_length=50, out=None):
+    def __init__(self, name, iterator, bar_length=50, out=None):
         if not (hasattr(iterator, 'current_position')
                 and hasattr(iterator, 'epoch_detail')):
             raise TypeError('Iterator must have the following attributes '
                             'to enable a progress bar: '
                             'current_position, epoch_detail')
+        self._name = name
         self._iterator = iterator
         self._bar_length = bar_length
 
@@ -277,8 +279,9 @@ class _IteratorProgressBar(util.ProgressBar):
 
         rate = epoch_detail
         marks = '#' * int(rate * self._bar_length)
-        lines.append('validation [{}{}] {:6.2%}\n'.format(
-                     marks, '.' * (self._bar_length - len(marks)), rate))
+        rest_marks = '.' * (self._bar_length - len(marks))
+        lines.append('{} [{}{}] {:6.2%}\n'.format(
+                     self._name, marks, rest_marks, rate))
 
         if epoch_size:
             lines.append('{:10} / {} iterations\n'
@@ -336,7 +339,8 @@ class IgniteEvaluator(Evaluator):
         self.summary = reporting.DictSummary()
         self.progress = IterationStatus(len(iterator))
         if self._progress_bar:
-            self.pbar = _IteratorProgressBar(iterator=self.progress)
+            name = self.name or self.default_name
+            self.pbar = _IteratorProgressBar(name=name, iterator=self.progress)
         self.evaluator.run(iterator)
         if self._progress_bar:
             self.pbar.close()

--- a/pytorch_pfn_extras/training/extensions/evaluator.py
+++ b/pytorch_pfn_extras/training/extensions/evaluator.py
@@ -284,16 +284,18 @@ class _IteratorProgressBar(util.ProgressBar):
                      self._name, marks, rest_marks, rate))
 
         if epoch_size:
-            lines.append('{:10} / {} iterations\n'
+            lines.append(f'{{:{len(self._name)}}} / {{}} iterations\n'
                          .format(iteration, epoch_size))
         else:
-            lines.append('{:10} iterations\n'.format(iteration))
+            lines.append(f'{{:{len(self._name)}}} iterations\n'
+                         .format(iteration))
 
         speed_t, speed_e = self.update_speed(iteration, epoch_detail)
         estimated_time = (1.0 - epoch_detail) / speed_e
-        lines.append('{:10.5g} iters/sec. Estimated time to finish: {}.\n'
-                     .format(speed_t,
-                             datetime.timedelta(seconds=estimated_time)))
+        itps = f'{{:{len(self._name)}.5g}} iters/sec.'.format(speed_t)
+        eta = 'Estimated time to finish: {}.\n' \
+              .format(datetime.timedelta(seconds=estimated_time))
+        lines.append("{} {}".format(itps, eta))
         return lines
 
 

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_evaluator.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_evaluator.py
@@ -190,7 +190,7 @@ def test_evaluator_with_eval_func():
             _torch_batch_to_numpy(target.args[i]), data[i])
 
 
-def test_evaluator_progress_bar():
+def test_evaluator_progress_bar(capsys):
     data = [
         numpy.random.uniform(-1, 1, (3, 4)).astype('f') for _ in range(2)]
 
@@ -203,6 +203,26 @@ def test_evaluator_progress_bar():
     reporter.add_observer('target', target)
     with reporter:
         evaluator.evaluate()
+    captured = capsys.readouterr()
+    assert 'validation [####' in captured.out
+
+
+def test_evaluator_progress_bar_custom_label(capsys):
+    data = [
+        numpy.random.uniform(-1, 1, (3, 4)).astype('f') for _ in range(2)]
+
+    data_loader = torch.utils.data.DataLoader(data, batch_size=1)
+    target = DummyModel()
+    evaluator = ppe.training.extensions.Evaluator(
+        data_loader, {}, eval_func=target, progress_bar=True)
+    evaluator.name = 'my_evaluator'     # Set custom name to the evaluator
+
+    reporter = ppe.reporting.Reporter()
+    reporter.add_observer('target', target)
+    with reporter:
+        evaluator.evaluate()
+    captured = capsys.readouterr()
+    assert 'my_evaluator [####' in captured.out
 
 
 # Code excerpts to test IgniteEvaluator


### PR DESCRIPTION
`Evaluator` with `progress_bar=True` shows this kind of simple progress bar which is very handy.
```
validation [#########################.........................] 50.00%
         1 iterations
    9642.1 iters/sec. Estimated time to finish: 0:00:00.000104.
```

The label of the progress bar is always set to "validation".

In case there are multiple evaluators set in a training loop, I feel that showing what is actually in progress right now would be slightly more helpful.
Each single Evaluator, which is an Extension, should basically have a unique name in an extension manager. Therefore I'd like to propose to show the name of an evaluator in its progress bar like below,

```
my_xxx_evaluator [#########################.........................] 50.00%
               1 iterations
          7358.4 iters/sec. Estimated time to finish: 0:00:00.000136.
```

in case the name of the Evaluator is set like this (as well as `progress_bar=True`).

```python
evaluator = ppe.training.extensions.Evaluator(..., progress_bar=True)
evaluator.name = 'my_xxx_evaluator'
```

Length of the name is considered accordingly so that the progress bar layout is kept consistent.
(Even if you set a long/short name than default like the above example, 2nd and 3rd lines of the progress bar shift as necessary)

In typical use cases where we have only one evaluator and haven't explicitly set its name, it keeps the current behavior i.e., just shows "validation".