### PR TITLE
Fix tests to avoid using args/kwargs attribute of Mock.call_args

### DIFF
--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot_writers.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot_writers.py
@@ -18,8 +18,8 @@ def test_simple_writer():
     with tempfile.TemporaryDirectory() as tempd:
         w('myfile.dat', tempd, target, savefun=savefun)
     assert savefun.call_count == 1
-    assert savefun.call_args.args[0] == target
-    assert savefun.call_args.kwargs['foo'] is True
+    assert savefun.call_args[0][0] == target
+    assert savefun.call_args[1]['foo'] is True
 
 
 def test_standard_writer():


### PR DESCRIPTION
This is needed as Mock.call_args.{args,kwargs} was added in Python 3.8.