### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
                 'development in PyTorch.',
     author='Preferred Networks, Inc.',
     license='MIT License',
-    install_requires=['numpy', 'torch'],
+    install_requires=['numpy', 'torch', 'ipython', 'ipywidgets'],
     extras_require={
         'test': ['pytest'],
         'onnx': ['onnx'],


### PR DESCRIPTION
When I use pytroch-pfn-extras

AttributeError: module 'pytorch_pfn_extras.training.extensions' has no attribute 'PrintReportNotebook'  occured

```python
try:

    from pytorch_pfn_extras.training.extensions.print_report_notebook import PrintReportNotebook  # NOQA
    from pytorch_pfn_extras.training.extensions.progress_bar_notebook import ProgressBarNotebook  # NOQA

    _ipython_module_available = True
except ImportError:
    _ipython_module_available = False
```

I found that PrintReportNotebook, and ProgressBarNotebook need requirements. So I add them to setup.py.
