### PR TITLE
Export record_function and record_iterable to public

### DIFF
--- a/pytorch_pfn_extras/profiler/__init__.py
+++ b/pytorch_pfn_extras/profiler/__init__.py
@@ -1,3 +1,5 @@
 from pytorch_pfn_extras.profiler._record import record  # NOQA
+from pytorch_pfn_extras.profiler._record import record_function  # NOQA
+from pytorch_pfn_extras.profiler._record import record_iterable  # NOQA
 from pytorch_pfn_extras.profiler._time_summary import time_summary  # NOQA
 from pytorch_pfn_extras.profiler._time_summary import TimeSummary  # NOQA


### PR DESCRIPTION
Add `record_function` and `record_iterable` to public. These two functions became private in changes of #226.