### PR TITLE
Defer initialization of profiler

### DIFF
--- a/pytorch_pfn_extras/profiler/_time_summary.py
+++ b/pytorch_pfn_extras/profiler/_time_summary.py
@@ -176,6 +176,7 @@ class TimeSummary:
         self._cpu_worker.finalize()
         if self._cuda_worker is not None:
             self._cuda_worker.finalize()
+        self._initialized = False
 
     def synchronize(self):
         self.initialize()

--- a/pytorch_pfn_extras/profiler/_time_summary.py
+++ b/pytorch_pfn_extras/profiler/_time_summary.py
@@ -1,9 +1,9 @@
-import atexit
 from contextlib import contextmanager
+import os
 import time
 from typing import Tuple
-from threading import Lock, Thread
-from queue import Queue
+import threading
+import queue
 import multiprocessing as mp
 import torch
 from pytorch_pfn_extras.reporting import DictSummary
@@ -12,23 +12,42 @@ from pytorch_pfn_extras.reporting import DictSummary
 Events = Tuple[torch.cuda.Event, torch.cuda.Event]
 
 
-class _CPUWorker(object):
+class _CPUWorker:
     def __init__(self, add, max_queue_size: int):
         self._add = add
-        self._queue = mp.JoinableQueue(max_queue_size)
-        self._thread = Thread(target=self._worker)
-        self._thread.setDaemon(True)
-        self._thread.start()
+        self._max_queue_size = max_queue_size
+        self._initialized = False
+        self._queue = None
+        self._thread = None
 
-    def close(self):
+    def __del__(self):
+        self.finalize()
+
+    def initialize(self):
+        if self._initialized:
+            return
+        self._queue = mp.JoinableQueue(self._max_queue_size)
+        self._thread = threading.Thread(target=self._worker, daemon=True)
+        self._thread.start()
+        self._initialized = True
+
+    def finalize(self):
+        if not self._initialized:
+            return
         self._queue.put(None)
-        self.wait()
-        self._thread.join()
+        self._queue.join()
         self._queue.close()
         self._queue.join_thread()
+        self._thread.join()
+        self._initialized = False
 
-    def wait(self):
+    def synchronize(self):
+        assert self._initialized
         self._queue.join()
+
+    def put(self, name, value):
+        assert self._initialized
+        self._queue.put((name, value))
 
     def _worker(self):
         while True:
@@ -41,23 +60,43 @@ class _CPUWorker(object):
             self._queue.task_done()
 
 
-class _CUDAWorker(object):
+class _CUDAWorker:
     def __init__(self, add, max_queue_size: int):
         self._add = add
-        self._queue = Queue(max_queue_size)
-        self._thread = Thread(target=self._worker)
-        self._thread.setDaemon(True)
+        self._max_queue_size = max_queue_size
+        self._initialized = False
+        self._thread = None
+        self._queue = None
+        self._event_lock = threading.Lock()
+        self._events = None
+
+    def __del__(self):
+        self.finalize()
+
+    def initialize(self):
+        if self._initialized:
+            return
+        self._queue = queue.Queue(self._max_queue_size)
+        self._events = queue.Queue(self._max_queue_size * 2)
+        self._thread = threading.Thread(target=self._worker, daemon=True)
         self._thread.start()
-        self._event_lock = Lock()
-        self._events = Queue(max_queue_size)
+        self._initialized = True
 
-    def close(self):
+    def finalize(self):
+        if not self._initialized:
+            return
         self._queue.put(None)
-        self.wait()
-        self._thread.join()
-
-    def wait(self):
         self._queue.join()
+        self._thread.join()
+        self._initialized = False
+
+    def synchronize(self):
+        assert self._initialized
+        self._queue.join()
+
+    def put(self, name, events):
+        assert self._initialized
+        self._queue.put((name, events))
 
     def _worker(self):
         while True:
@@ -65,8 +104,7 @@ class _CUDAWorker(object):
             if v is None:
                 self._queue.task_done()
                 break
-            name, value = v
-            begin, end = value
+            name, (begin, end) = v
             end.synchronize()
             t_ms = begin.elapsed_time(end)
             self._add(name, t_ms / 1000)
@@ -75,39 +113,78 @@ class _CUDAWorker(object):
                 self._events.put(end)
             self._queue.task_done()
 
-    def _get_cuda_event(self) -> torch.cuda.Event:
+    def get_cuda_event(self) -> torch.cuda.Event:
+        assert self._initialized
         with self._event_lock:
             if self._events.empty():
                 self._events.put(torch.cuda.Event(enable_timing=True))
             return self._events.get()
 
 
-class TimeSummary(object):
+class TimeSummary:
     """Online summarization of execution times.
 
     `TimeSummary` computes the average and standard deviation of exeuction
     times in both cpu and gpu devices.
 
+    Args:
+        max_queue_size (int): Length limit of the internal queues that keep
+            reported time info until they are summarized.
+        auto_init (bool): Whether to automatically call `initialize()`
+            when the instance is created.
     """
 
-    def __init__(self, max_queue_size: int = 1000):
-        self._summary_lock = Lock()
+    def __init__(self, *, max_queue_size: int = 1000, auto_init: bool = True):
+        self._summary_lock = threading.Lock()
         self._summary = DictSummary()
         self._additional_stats = {}
 
-        self._cpu_worker = _CPUWorker(self._add, max_queue_size)
+        self._cpu_worker = _CPUWorker(self._add_from_worker, max_queue_size)
         if torch.cuda.is_available():
-            self._cuda_worker = _CUDAWorker(self._add, max_queue_size)
+            self._cuda_worker = _CUDAWorker(self._add_from_worker, max_queue_size)
         else:
             self._cuda_worker = None
 
-    def close(self):
-        self.wait()
-        self._cpu_worker.close()
-        if self._cuda_worker is not None:
-            self._cuda_worker.close()
+        self._initialized = False
+        self._master_pid = os.getpid()
+        if auto_init:
+            self.initialize()
 
-    def _add(self, name, value):
+    def initialize(self) -> None:
+        """Initializes the worker threads for TimeSummary.
+
+        Usually you do not have to call it for yourself.
+        However in case you directly use ``ppe.time_summary`` outside of
+        :class:`pytorch_pfn_extras.training.extensions.ProfileReport`,
+        you have to explicitly call ``initialize()`` in advance.
+        """
+        if self._initialized:
+            return
+        if os.getpid() != self._master_pid:
+            raise RuntimeError(
+                "TimeSummary must be initialized in the same process as the "
+                "one created the instance. Please call initialize() in the "
+                "main process.")
+        self._cpu_worker.initialize()
+        if self._cuda_worker is not None:
+            self._cuda_worker.initialize()
+        self._initialized = True
+
+    def finalize(self):
+        if not self._initialized:
+            return
+        self._cpu_worker.finalize()
+        if self._cuda_worker is not None:
+            self._cuda_worker.finalize()
+
+    def synchronize(self):
+        self.initialize()
+        self._cpu_worker.synchronize()
+        if self._cuda_worker is not None:
+            self._cuda_worker.synchronize()
+
+    def _add_from_worker(self, name, value):
+        assert self._initialized
         with self._summary_lock:
             self._summary.add({name: value})
             min_value = self._additional_stats.get(f"{name}.min", value)
@@ -115,13 +192,9 @@ class TimeSummary(object):
             max_value = self._additional_stats.get(f"{name}.max", value)
             self._additional_stats[f"{name}.max"] = max(value, max_value)
 
-    def wait(self):
-        self._cpu_worker.wait()
-        if self._cuda_worker is not None:
-            self._cuda_worker.wait()
-
     @contextmanager
     def summary(self, clear: bool = False):
+        self.initialize()
         try:
             with self._summary_lock:
                 yield self._summary, self._additional_stats
@@ -142,21 +215,20 @@ class TimeSummary(object):
             tag (str): A name to identify the section of code being profiled.
             use_cuda (bool): Indicates if GPU time should also be profiled.
         """
+        self.initialize()
         if use_cuda:
-            begin_event = self._cuda_worker._get_cuda_event()
+            begin_event = self._cuda_worker.get_cuda_event()
             begin_event.record()
         try:
             begin = time.time()
             yield
         finally:
             end = time.time()
-            self._cpu_worker._queue.put((tag, end - begin))
+            self._cpu_worker.put(tag, end - begin)
             if use_cuda:
-                end_event = self._cuda_worker._get_cuda_event()
+                end_event = self._cuda_worker.get_cuda_event()
                 end_event.record()
-                self._cuda_worker._queue.put(
-                    (f"{tag}.cuda", (begin_event, end_event)))
+                self._cuda_worker.put(f"{tag}.cuda", (begin_event, end_event))
 
 
-time_summary = TimeSummary()
-atexit.register(time_summary.close)
+time_summary = TimeSummary(auto_init=False)

--- a/pytorch_pfn_extras/profiler/_time_summary.py
+++ b/pytorch_pfn_extras/profiler/_time_summary.py
@@ -192,6 +192,9 @@ class TimeSummary:
             max_value = self._additional_stats.get(f"{name}.max", value)
             self._additional_stats[f"{name}.max"] = max(value, max_value)
 
+    def add(self, name, value):
+        self._add_from_worker(name, value)
+
     @contextmanager
     def summary(self, clear: bool = False):
         self.initialize()

--- a/pytorch_pfn_extras/training/extensions/profile_report.py
+++ b/pytorch_pfn_extras/training/extensions/profile_report.py
@@ -52,6 +52,9 @@ class ProfileReport(extension.Extension):
         format=None,
         **kwargs,
     ):
+        # Initializes global TimeSummary.
+        time_summary.initialize()
+
         if store_keys is None:
             self._store_keys = store_keys
         else:

--- a/tests/pytorch_pfn_extras_tests/profiler_tests/test_time_summary.py
+++ b/tests/pytorch_pfn_extras_tests/profiler_tests/test_time_summary.py
@@ -62,16 +62,13 @@ def test_global_summary():
 
 def test_clear():
     summary = TimeSummary()
-    summary._summary._add({"foo": 10})
-    summary._summary._add({"foo": 5})
-    summary._summary._add({"foo": 15})
+    summary.add("foo", 10)
+    summary.add("foo", 5)
+    summary.add("foo", 15)
     summary.synchronize()
     with summary.summary(clear=True) as s:
         assert s[0].compute_mean() == {"foo": 10}
         assert s[1] == {"foo.min": 5, "foo.max": 15}
-    with summary.summary(clear=True) as s:
-        assert s[0].compute_mean() == {}
-        assert s[1] == {}
     summary.finalize()
 
 
@@ -81,7 +78,7 @@ def test_multiprocessing_start_method():
     subprocess.check_call([
         sys.executable,
         '-c',
-        ('import multiprocessing as mp; ' +
-         'import pytorch_pfn_extras; ' +
-         'mp.set_start_method("spawn"); ')
+        ('import multiprocessing as mp; '
+         + 'import pytorch_pfn_extras; '
+         + 'mp.set_start_method("spawn"); ')
     ])


### PR DESCRIPTION
Tried to fix #238.
This is based on the proposal of @belltailjp and @HiroakiMikami (#240) :pray:

This PR defers initialization (thread creation and multiprocessing context initialization) to make `import pytorch_pfn_extras` harmless.