### PR TITLE
Update setuptools and pip before installing PyTorch

### DIFF
--- a/.flexci/windows/test.ps1
+++ b/.flexci/windows/test.ps1
@@ -7,35 +7,41 @@ $ErrorActionPreference = "Stop"
 
 . "$PSScriptRoot\_flexci.ps1"
 
+
 # Setup environment
 if ($test -eq "torch15") {
     # PyTorch 1.5 + Python 3.6
     ActivateCUDA 10.2
     ActivatePython 3.6
+    RunOrDie python -m pip install -U pip setuptools
     RunOrDie python -m pip install torch==1.5.* torchvision==0.6.* -f https://download.pytorch.org/whl/torch_stable.html
 
 } elseif ($test -eq "torch16") {
     # PyTorch 1.6 + Python 3.7
     ActivateCUDA 10.2
     ActivatePython 3.7
+    RunOrDie python -m pip install -U pip setuptools
     RunOrDie python -m pip install torch==1.6.* torchvision==0.7.* -f https://download.pytorch.org/whl/torch_stable.html
 
 } elseif ($test -eq "torch17") {
     # PyTorch 1.7 + Python 3.6
     ActivateCUDA 10.2
     ActivatePython 3.6
+    RunOrDie python -m pip install -U pip setuptools
     RunOrDie python -m pip install torch==1.7.* torchvision==0.8.* -f https://download.pytorch.org/whl/torch_stable.html
 
 } elseif ($test -eq "torch18") {
     # PyTorch 1.8 + Python 3.8
     ActivateCUDA 11.1
     ActivatePython 3.8
+    RunOrDie python -m pip install -U pip setuptools
     RunOrDie python -m pip install torch==1.8.* torchvision==0.9.* -f https://download.pytorch.org/whl/cu111/torch_stable.html
 
 } elseif ($test -eq "torch19") {
     # PyTorch 1.9 + Python 3.9
     ActivateCUDA 11.1
     ActivatePython 3.9
+    RunOrDie python -m pip install -U pip setuptools
     RunOrDie python -m pip install torch==1.9.* torchvision==0.10.* -f https://download.pytorch.org/whl/cu111/torch_stable.html
 
 } else {
@@ -44,7 +50,6 @@ if ($test -eq "torch15") {
 RunOrDie python -V
 
 # Install common requirements
-RunOrDie python -m pip install -U setuptools
 RunOrDie python -m pip install pytorch-ignite pytest flake8 matplotlib tensorboard onnx ipython ipywidgets pandas optuna cupy-cuda102
 RunOrDie python -m pip list
 


### PR DESCRIPTION
PyTorch download often fails in Windows CI.
This PR is almost just a wild guess, but would first like to eliminate possibility that outdated setuptools/pip is the reason of the failure.

https://ci.preferred.jp/pytorch-pfn-extras.torch19-win/76826/