### PR TITLE
Do `autocast` only on forward

### DIFF
--- a/pytorch_pfn_extras/handler.py
+++ b/pytorch_pfn_extras/handler.py
@@ -221,9 +221,6 @@ class Handler(BaseHandler):
         self._eval_report_keys = options.pop('eval_report_keys', [])
         self._train_report_keys = options.pop('train_report_keys', [])
         self._async = options.pop('async', False)
-        if self._autocast and not _amp_enabled:
-            raise RuntimeError('Requested AMP features but torch.cuda.amp'
-                               ' is not enabled')
 
     def _runtime_iterator(self, models):
         if not self._ppe_modules:
@@ -598,7 +595,7 @@ class Logic(BaseLogic):
         self._autocast = options.pop('autocast', False)
 
         if not _amp_enabled:
-            if self._grad_scaler is not None or not self._autocast:
+            if self._grad_scaler is not None or self._autocast:
                 raise RuntimeError('Requested AMP features but torch.cuda.amp'
                                    ' is not enabled')
 

--- a/pytorch_pfn_extras/handler.py
+++ b/pytorch_pfn_extras/handler.py
@@ -569,7 +569,7 @@ class Logic(BaseLogic):
 
         Args:
             model_name (str): Name of the model. Default is ``'main'``.
-            options (dict, optional): Options for backward computation.
+            options (dict, optional): The configuration options.
 
                 * ``'backward_outputs'`` (list of str):
                     A list of names of outputs that require compution of

--- a/pytorch_pfn_extras/handler.py
+++ b/pytorch_pfn_extras/handler.py
@@ -27,9 +27,6 @@ def torch_autocast(enabled=True):
         yield
 
 
-_is_torch_17 = torch.__version__.split('.')[1] == '7'
-
-
 class BaseHandler:
 
     def __init__(self, logic, options, *args, **kwargs):

--- a/pytorch_pfn_extras/handler.py
+++ b/pytorch_pfn_extras/handler.py
@@ -192,9 +192,6 @@ class Handler(BaseHandler):
             entry_runtime (BaseRuntime): A runtime object.
             options (dict): The configuration options.
 
-                * ``'autocast'`` (bool):
-                    If ``True``, torch.cuda.amp.autocast is enabled.
-                    Default is ``False``.
                 * ``'eval_report_keys'`` (list of str):
                     A list of names of outputs that are given as inputs
                     of ``reporting.report`` after each evaluation step.
@@ -578,6 +575,9 @@ class Logic(BaseLogic):
             * ``'backward_outputs'`` (list of str):
                 A list of names of outputs that require compution of
                 the gradient.
+            * ``'autocast'`` (bool):
+                If ``True``, ``torch.cuda.amp.autocast`` is enabled.
+                Default is ``False``.
             * ``'grad_scaler'`` (torch.cuda.amp.GradScaler):
                 A gradient scaler that outputs are applied to.
         """

--- a/pytorch_pfn_extras/handler.py
+++ b/pytorch_pfn_extras/handler.py
@@ -196,7 +196,7 @@ class Handler(BaseHandler):
                     A list of names of outputs that are given as inputs
                     of ``reporting.report`` after each evaluation step.
                     Default is an empty list.
-                * ``'train_report_keys'``
+                * ``'train_report_keys'`` (list of str):
                     A list of names of outputs that are given as inputs
                     of ``reporting.report`` after each training step.
                     Default is an empty list.

--- a/pytorch_pfn_extras/handler.py
+++ b/pytorch_pfn_extras/handler.py
@@ -567,19 +567,18 @@ class Logic(BaseLogic):
     def __init__(self, model_name='main', options=None):
         """A set of methods that defines the training logic.
 
-        model_name (str):
-            Name of the model. Default is ``'main'``.
-        options (dict, optional):
-            Options for backward computation.
+        Args:
+            model_name (str): Name of the model. Default is ``'main'``.
+            options (dict, optional): Options for backward computation.
 
-            * ``'backward_outputs'`` (list of str):
-                A list of names of outputs that require compution of
-                the gradient.
-            * ``'autocast'`` (bool):
-                If ``True``, ``torch.cuda.amp.autocast`` is enabled.
-                Default is ``False``.
-            * ``'grad_scaler'`` (torch.cuda.amp.GradScaler):
-                A gradient scaler that outputs are applied to.
+                * ``'backward_outputs'`` (list of str):
+                    A list of names of outputs that require compution of
+                    the gradient.
+                * ``'autocast'`` (bool):
+                    If ``True``, ``torch.cuda.amp.autocast`` is enabled.
+                    Default is ``False``.
+                * ``'grad_scaler'`` (torch.cuda.amp.GradScaler):
+                    A gradient scaler that outputs are applied to.
         """
         super().__init__(options)
         self.model_name = model_name

--- a/tests/pytorch_pfn_extras_tests/test_handler.py
+++ b/tests/pytorch_pfn_extras_tests/test_handler.py
@@ -332,9 +332,9 @@ class TestHandlerAutocast:
     @pytest.mark.parametrize('autocast', [True, False])
     def test_autocast(self, autocast):
         trainer = MockTrainer()
-        logic = ppe.handler.Logic()
+        logic = ppe.handler.Logic(options={'autocast': autocast})
         handler = ppe.handler.Handler(
-            logic, ppe.runtime.PyTorchRuntime('cuda'), {'autocast': autocast}
+            logic, ppe.runtime.PyTorchRuntime('cuda'), {}
         )
 
         completed = False
@@ -369,12 +369,8 @@ class TestHandlerAutocast:
         old_enable = ppe.handler._amp_enabled
         try:
             ppe.handler._amp_enabled = False
-            logic = ppe.handler.Logic()
             with pytest.raises(RuntimeError):
-                ppe.handler.Handler(
-                    logic, ppe.runtime.PyTorchRuntime('cuda'),
-                    {'autocast': True}
-                )
+                ppe.handler.Logic(options={'autocast': True})
         finally:
             ppe.handler._amp_enabled = old_enable
 


### PR DESCRIPTION
Since torch 1.8 the autocast & checkpointing seems to be fixed, so we apply it only to the forward pass.