### PR TITLE
skip assert when a model returns tensor

### DIFF
--- a/pytorch_pfn_extras/handler.py
+++ b/pytorch_pfn_extras/handler.py
@@ -584,7 +584,8 @@ class Logic(BaseLogic):
         to_back_outs = outs
         if self._grad_scaler is not None:
             to_back_outs = self._normalize_outputs(outs)
-            assert len(outs) == 1, "loss scaling with multiple outputs is not supported"
+            if not isinstance(outs, torch.Tensor):
+                assert len(outs) == 1, "loss scaling with multiple outputs is not supported"
             to_back_outs = {
                 k: self._grad_scaler.scale(v) for k, v in to_back_outs.items()}
         self._backward(to_back_outs)

--- a/pytorch_pfn_extras/handler.py
+++ b/pytorch_pfn_extras/handler.py
@@ -585,7 +585,9 @@ class Logic(BaseLogic):
         if self._grad_scaler is not None:
             to_back_outs = self._normalize_outputs(outs)
             if not isinstance(outs, torch.Tensor):
-                assert len(outs) == 1, "loss scaling with multiple outputs is not supported"
+                assert (
+                    len(outs) == 1
+                ), "loss scaling with multiple outputs is not supported"
             to_back_outs = {
                 k: self._grad_scaler.scale(v) for k, v in to_back_outs.items()}
         self._backward(to_back_outs)


### PR DESCRIPTION
The assertion triggers false positively.

This happens when I use a loss function that returns tensor (not tuple, dict, ...).