### PR TITLE
Make manager state consistent and allow to synchronize in the handler

### DIFF
--- a/pytorch_pfn_extras/training/_trainer.py
+++ b/pytorch_pfn_extras/training/_trainer.py
@@ -100,6 +100,9 @@ class _Trainer(pytorch_pfn_extras.engine._Engine):
         self.evaluator.run(self._val_loader, eval_len=self._eval_len)
         self.evaluator.handler.train_validation_end(self, self.evaluator)
 
+    def synchronize(self):
+        self.handler.synchronize_train(self)
+
     def run(self,
             train_loader: torch.utils.data.DataLoader,
             val_loader: Optional[torch.utils.data.DataLoader] = None,

--- a/pytorch_pfn_extras/training/_trainer.py
+++ b/pytorch_pfn_extras/training/_trainer.py
@@ -22,9 +22,6 @@ class _Trainer(pytorch_pfn_extras.engine._Engine):
             self.evaluator = evaluator
             self.evaluator_trigger = trigger_module.get_trigger((1, 'epoch'))
         self.val_loader = None
-        self._sync_trigger = kwargs.pop('sync_trigger', None)
-        if self._sync_trigger is not None:
-            self._sync_trigger = trigger_module.get_trigger(self._sync_trigger)
 
     @property
     def epoch(self):
@@ -202,11 +199,6 @@ class _Trainer(pytorch_pfn_extras.engine._Engine):
                             self._profile_records.put([ntf0, ntf1, ntf2])
                             self.handler.train_step(
                                 self, idx, x, complete_fn=self._complete_step)
-                            if (
-                                self._sync_trigger is not None
-                                and self._sync_trigger(self.manager)
-                            ):
-                                self.handler.synchronize_train(self)
                             # Check if the callback was called
                             if self._deferred:
                                 # The iteration will be completed later

--- a/pytorch_pfn_extras/training/_trainer.py
+++ b/pytorch_pfn_extras/training/_trainer.py
@@ -22,6 +22,9 @@ class _Trainer(pytorch_pfn_extras.engine._Engine):
             self.evaluator = evaluator
             self.evaluator_trigger = trigger_module.get_trigger((1, 'epoch'))
         self.val_loader = None
+        self._sync_trigger = kwargs.pop('sync_trigger', None)
+        if self._sync_trigger is not None:
+            self._sync_trigger = trigger_module.get_trigger(self._sync_trigger)
 
     @property
     def epoch(self):
@@ -199,6 +202,11 @@ class _Trainer(pytorch_pfn_extras.engine._Engine):
                             self._profile_records.put([ntf0, ntf1, ntf2])
                             self.handler.train_step(
                                 self, idx, x, complete_fn=self._complete_step)
+                            if (
+                                self._sync_trigger is not None
+                                and self._sync_trigger(self.manager)
+                            ):
+                                self.handler.synchronize_train(self)
                             # Check if the callback was called
                             if self._deferred:
                                 # The iteration will be completed later

--- a/pytorch_pfn_extras/training/extension.py
+++ b/pytorch_pfn_extras/training/extension.py
@@ -151,6 +151,9 @@ class _WrappedExtension(Extension):
         self._ext = ext
         self.trigger = getattr(self._ext, 'trigger', Extension.trigger)
         self.priority = getattr(self._ext, 'priority', Extension.priority)
+        self.is_async = getattr(self._ext, 'is_async', False)
+        self.needs_sync = getattr(self._ext, 'needs_sync', False)
+        self.object_to_sync = getattr(self._ext, 'object_to_sync', None)
         super().__init__()
 
     @property

--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -302,6 +302,7 @@ class _Snapshot(extension.Extension):
     trigger = 1, 'epoch'
     priority = extension.PRIORITY_SNAPSHOT
     needs_model_state = True
+    needs_sync = True
 
     def __init__(
             self, target=None, condition=None, writer=None,
@@ -318,6 +319,10 @@ class _Snapshot(extension.Extension):
         self.n_retains = n_retains
         self.autoload = autoload
         self._savefun = savefun
+        if callable(getattr(target, 'synchronize', None)):
+            self.object_to_sync = target
+        else:
+            self.needs_sync = False
 
     def initialize(self, manager):
         target = manager if self._target is None else self._target

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -463,7 +463,6 @@ class _BaseExtensionsManager:
     ) -> Dict[str, Any]:
         to_save: Dict[str, Any] = {}
         to_save['_start_iteration'] = self.iteration
-        to_save['_start_execution'] = self.execution
         # Use self.models to apply transform_model
         to_save['models'] = {
             name: self.models[name].state_dict()
@@ -480,8 +479,7 @@ class _BaseExtensionsManager:
     ) -> None:
         self._start_iteration = to_load['_start_iteration']
         self.iteration = self._start_iteration
-        self._start_execution = to_load.get('_start_execution', self.iteration)
-        self.execution = self._start_execution
+        self.execution = self.iteration
         for name in self.models:
             # TODO(ecastill) map_loc when loading the model and DDP check
             # Use self.models to apply transform_model

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -254,11 +254,10 @@ class _BaseExtensionsManager:
     def _prepare_for_training(
             self,
             start_iteration: int,
-            start_execution: int,
             iters_per_epoch: int
     ) -> None:
         self.iteration = start_iteration
-        self.execution = start_execution
+        self.execution = start_iteration
         self._iters_per_epoch = iters_per_epoch
 
     def start_extensions(self) -> None:
@@ -532,7 +531,7 @@ class ExtensionsManager(_BaseExtensionsManager):
             raise ValueError(
                 'iters_per_epoch must be an integer >= 1 ({} given)'.format(
                     iters_per_epoch))
-        self._prepare_for_training(0, 0, iters_per_epoch)
+        self._prepare_for_training(0, iters_per_epoch)
 
     @contextlib.contextmanager
     def complete_iteration(self, *, observation=None, step_optimizers=None):
@@ -673,7 +672,7 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
         def set_training_started(engine: Engine) -> None:
             iters_per_epoch = len(engine.state.dataloader)
             # Initialize manager once before extensions' `initialize` call
-            self._prepare_for_training(0, 0, iters_per_epoch)
+            self._prepare_for_training(0, iters_per_epoch)
             self.start_extensions()
             start_iteration = self._start_iteration
             self.engine.state.iteration = self._start_iteration
@@ -681,7 +680,7 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
             self._start_time = _get_time()
             # Initialize manager again after all state is restored
             self._prepare_for_training(
-                start_iteration, start_iteration, iters_per_epoch)
+                start_iteration, iters_per_epoch)
 
             # Make all the next
             # handlers to be executed after user defined ones

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
@@ -174,7 +174,6 @@ def test_extensions_manager_state_dict():
     state_dict = manager.state_dict()
 
     assert state_dict == {
-        '_start_execution': passed_iteration,
         '_start_iteration': passed_iteration,
         'models': {'model_name': model_state_dict},
         'optimizers': {'optimizer_name': optimizer_state_dict},
@@ -239,7 +238,6 @@ def test_ignite_extensions_manager_state_dict():
     state_dict = manager.state_dict()
 
     assert state_dict == {
-        '_start_execution': passed_iteration,
         '_start_iteration': passed_iteration,
         '_epoch_length': iters_per_epoch,
         'models': {'model_name': model_state_dict},
@@ -287,7 +285,6 @@ def test_extensions_manager_with_plain_model_and_optimizer():
     state_dict = manager.state_dict()
 
     assert state_dict == {
-        '_start_execution': 0,
         '_start_iteration': 0,
         'models': {'main': model_state_dict},
         'optimizers': {'main': optimizer_state_dict},


### PR DESCRIPTION
we should load the state with `exeuction=iteration` since the on-going executions do not exists when restoring the state, and this leads to an inconsistent state.

cc @HiroakiMikami 