### PR TITLE
doc: Move type annotation to description from signature

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,8 @@ extensions = [
     'myst_parser',
 ]
 
+autodoc_typehints = "description"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
This is a resubmit of #241 to `trainer-dev` branch as it was out of synchronization.