### PR TITLE
Backprop only when grad is enabled

### DIFF
--- a/pytorch_pfn_extras/handler.py
+++ b/pytorch_pfn_extras/handler.py
@@ -630,6 +630,7 @@ class Logic(BaseLogic):
             # This is to avoid errors when the trained models returns
             # tensors others than scalars
             if isinstance(v, torch.Tensor) and (
+                v.grad_fn is not None and
                 (
                     self.backward_outputs is None
                     and v.numel() == 1

--- a/pytorch_pfn_extras/handler.py
+++ b/pytorch_pfn_extras/handler.py
@@ -629,8 +629,7 @@ class Logic(BaseLogic):
         for k, v in target.items():
             # This is to avoid errors when the trained models returns
             # tensors others than scalars
-            if isinstance(v, torch.Tensor) and (
-                v.grad_fn is not None and
+            if isinstance(v, torch.Tensor) and v.grad_fn is not None and (
                 (
                     self.backward_outputs is None
                     and v.numel() == 1


### PR DESCRIPTION
In some cases we want to skip the backprop call if the outputs didn't have grad_fn enabled.