### PR TITLE
Remove `examples` from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ mypy_preset = "strict"
 line_length = 80
 
 [[tool.pysen.lint.mypy_targets]]
-  paths = ["pytorch_pfn_extras", "example"]
+  paths = ["pytorch_pfn_extras"]


### PR DESCRIPTION
It is quite annoying to have to go through all these known errors when looking the mypy output for other files