### PR TITLE
Fix bug in train_step

### DIFF
--- a/pytorch_pfn_extras/handler/_logic.py
+++ b/pytorch_pfn_extras/handler/_logic.py
@@ -277,7 +277,7 @@ class Logic(BaseLogic):
             if self._grad_scaler is not None:
                 to_back_outs = self._normalize_outputs(outs)
                 assert (
-                    len(outs) == 1
+                    len(to_back_outs) == 1
                 ), "loss scaling with multiple outputs is not supported"
                 to_back_outs = {
                     k: self._grad_scaler.scale(v)

--- a/tests/pytorch_pfn_extras_tests/test_handler.py
+++ b/tests/pytorch_pfn_extras_tests/test_handler.py
@@ -398,7 +398,15 @@ class TestLogic:
     def _run_step(self, logic, device):
         input = torch.rand(1, 1).to(device)
         input.requires_grad = True
-        model = torch.nn.Linear(1, 1).to(device)
+
+        class _Module(torch.nn.Linear):
+            def __init__(self) -> None:
+                super().__init__(1, 1)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return super().forward(x).sum()
+
+        model = _Module().to(device)
         models = {'main': model}
         optimizers = {'main': torch.optim.SGD(model.parameters(), 1.0, 0)}
         out = logic.train_step(models, optimizers, 0, input)


### PR DESCRIPTION
`train_step` raises error (`TypeError: len() of a 0-d tensor `) when using amp and output is a scalar tensor.