### PR TITLE
Retry PyTorch install in Windows CI

### DIFF
--- a/.flexci/windows/_error_handler.ps1
+++ b/.flexci/windows/_error_handler.ps1
@@ -10,6 +10,20 @@ function RunOrDie {
     $global:LastExitCode = 0
     & $cmd @params
     if (-not $?) {
-        throw "Command failed (exit code = $LastExitCode): $args"
+        throw "Command failed (exit code = $LastExitCode): $cmd $params"
     }
+}
+
+function RunOrDieWithRetry {
+    $retry, $cmd, $params = $args
+    for ($i = 1; $i -le $retry; $i++) {
+        try {
+            RunOrDie $cmd $params
+            return
+        } catch {
+            $errmsg = $error[0]
+            Write-Host "RunOrDieWithRetry (attempt ${i}): ${errmsg}"
+        }
+    }
+    throw "No more retry."
 }

--- a/.flexci/windows/test.ps1
+++ b/.flexci/windows/test.ps1
@@ -14,14 +14,14 @@ if ($test -eq "torch18") {
     ActivateCUDA 11.1
     ActivatePython 3.7
     RunOrDie python -m pip install -U pip setuptools
-    RunOrDie python -m pip install torch==1.8.* torchvision==0.9.* -f https://download.pytorch.org/whl/cu111/torch_stable.html
+    RunOrDieWithRetry 3 python -m pip install torch==1.8.* torchvision==0.9.* -f https://download.pytorch.org/whl/cu111/torch_stable.html
 
 } elseif ($test -eq "torch19") {
     # PyTorch 1.9 + Python 3.8
     ActivateCUDA 11.1
     ActivatePython 3.8
     RunOrDie python -m pip install -U pip setuptools
-    RunOrDie python -m pip install torch==1.9.* torchvision==0.10.* -f https://download.pytorch.org/whl/cu111/torch_stable.html
+    RunOrDieWithRetry 3 python -m pip install torch==1.9.* torchvision==0.10.* -f https://download.pytorch.org/whl/cu111/torch_stable.html
 
 } else {
     throw "Unsupported test variant: $test"


### PR DESCRIPTION
PyTorch installation on Windows fails so frequently.

> pip._vendor.urllib3.exceptions.ProtocolError: ("Connection broken: ConnectionResetError(10054, 'An existing connection was forcibly closed by the remote host', None, 10054, None)", ConnectionResetError(10054, 'An existing connection was forcibly closed by the remote host', None, 10054, None))

https://ci.preferred.jp/pytorch-pfn-extras.torch19-win/79921/

This PR tries to solve it by retrying installation.