### PR TITLE
[onnx] Consider tensors using external data

### DIFF
--- a/pytorch_pfn_extras/onnx/strip_large_tensor.py
+++ b/pytorch_pfn_extras/onnx/strip_large_tensor.py
@@ -27,7 +27,7 @@ def _is_stripped_or_set_external(tensor):
             return external_value_dict.get('type', '') == 'stripped'
         except ValueError:
             # Invalid JSON, indicating `external_data.value` contains
-            # a file path, assume the tensor has no value means already stripped
+            # a file path. Treat the tensor as if it is already stripped.
             return True
     return False
 

--- a/pytorch_pfn_extras/onnx/strip_large_tensor.py
+++ b/pytorch_pfn_extras/onnx/strip_large_tensor.py
@@ -18,7 +18,7 @@ def is_large_tensor(tensor, threshold):
     return size > threshold
 
 
-def _is_stripped(tensor):
+def _is_stripped_or_set_external(tensor):
     for external_data in tensor.external_data:
         if external_data.key != 'location':
             continue
@@ -49,7 +49,7 @@ def _strip_raw_data(tensor):
 
 def _strip_large_initializer_raw_data_from_graph(graph, large_tensor_threshold):
     for init in graph.initializer:
-        if _is_stripped(init):
+        if _is_stripped_or_set_external(init):
             continue
         if is_large_tensor(init, large_tensor_threshold):
             _strip_raw_data(init)

--- a/pytorch_pfn_extras/onnx/strip_large_tensor.py
+++ b/pytorch_pfn_extras/onnx/strip_large_tensor.py
@@ -27,8 +27,8 @@ def _is_stripped(tensor):
             return external_value_dict.get('type', '') == 'stripped'
         except ValueError:
             # Invalid JSON, indicating `external_data.value` contains
-            # a file path
-            continue
+            # a file path, assume the tensor has no value means already stripped
+            return True
     return False
 
 


### PR DESCRIPTION
If the target tensor uses `external_data`, cannot convert to numpy array when the external data is in the `location`. Object of strip function is to reduce ONNX size, so assume that the goal is accomplished. If valid `location` is set = invalid JSON is set, skip strip.