### PR TITLE
`ppe.onnx.trace`: Clear additional outputs before model.forward

### DIFF
--- a/pytorch_pfn_extras/onnx/_as_output.py
+++ b/pytorch_pfn_extras/onnx/_as_output.py
@@ -18,6 +18,9 @@ class _Outputs:
     def __init__(self) -> None:
         self._values = []
 
+    def clear(self):
+        self._values.clear()
+
     @property
     def values(self) -> List[_Output]:
         return self._values
@@ -62,6 +65,7 @@ class _ModuleWithAdditionalOutputs(torch.nn.Module):
         self.outputs = outputs
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
+        self.outputs.clear()
         out = self.module(*args, **kwargs)
         if len(self.outputs.values) == 0:
             return out

--- a/pytorch_pfn_extras/onnx/_as_output.py
+++ b/pytorch_pfn_extras/onnx/_as_output.py
@@ -18,7 +18,7 @@ class _Outputs:
     def __init__(self) -> None:
         self._values = []
 
-    def clear(self):
+    def clear(self) -> None:
         self._values.clear()
 
     @property


### PR DESCRIPTION
`torch.jit.trace` calls `forward` multiple times. (cc: @HiroakiMikami @take-cheeze)