### PR TITLE
[WIP] Allow to return dict of `DeferredResult`

### DIFF
--- a/pytorch_pfn_extras/training/_evaluator.py
+++ b/pytorch_pfn_extras/training/_evaluator.py
@@ -84,6 +84,7 @@ class Evaluator:
         x = self._inputs.get()
         observed = self._observed.get()
         with self._reporter.scope(observed):
+            self.handler.preprocess_eval_outs(self, outs)
             outs = self._process_metrics(x, outs)
             self.handler.eval_post_step(self, idx, x, outs)
         self._summary.add(observed)


### PR DESCRIPTION
In some cases, instead of returning an awaitable object that yields the dict of the results, we would like to report a dict with entries of awaitable objects.

Also, in such a scenario, we would like to preprocess these awaitable objects before calculating metrics for evaluation, this PR adds a new callback to handler/runtime to be invoked right after a deferred result becomes available.