### PR TITLE
Allow to return dict of `DeferredResult`

### DIFF
--- a/pytorch_pfn_extras/handler/_handler.py
+++ b/pytorch_pfn_extras/handler/_handler.py
@@ -371,7 +371,6 @@ class Handler(BaseHandler):
             trainer (Trainer): The trainer that calls this method.
         """
         while self.pending_iters:
-            # TODO(ecastill) block until we get the result
             for sn, sm, rt in self._runtime_iterator(trainer.models):
                 t_outs = self._get_deferred_outputs(
                     self.pending_iters[sn][0], True)
@@ -607,7 +606,6 @@ class Handler(BaseHandler):
             evaluator (Evaluator): The evaluator.
         """
         while self.pending_iters:
-            # TODO(ecastill) block until we get the result
             for sn, sm, rt in self._runtime_iterator(evaluator.models):
                 t_outs = self._get_deferred_outputs(
                     self.pending_iters[sn][0], True)

--- a/pytorch_pfn_extras/training/_evaluator.py
+++ b/pytorch_pfn_extras/training/_evaluator.py
@@ -84,7 +84,6 @@ class Evaluator:
         x = self._inputs.get()
         observed = self._observed.get()
         with self._reporter.scope(observed):
-            self.handler.preprocess_eval_outs(self, outs)
             outs = self._process_metrics(x, outs)
             self.handler.eval_post_step(self, idx, x, outs)
         self._summary.add(observed)

--- a/pytorch_pfn_extras/training/_evaluator.py
+++ b/pytorch_pfn_extras/training/_evaluator.py
@@ -84,6 +84,7 @@ class Evaluator:
         x = self._inputs.get()
         observed = self._observed.get()
         with self._reporter.scope(observed):
+            self.handler.preprocess_eval_outs(self, outs)
             outs = self._process_metrics(x, outs)
             self.handler.eval_post_step(self, idx, x, outs)
         self._summary.add(observed)


### PR DESCRIPTION
In some cases, instead of returning an awaitable object that yields the dict of the results, we would like to return a dict with entries of awaitable objects.