### PR TITLE
Make comparer error message comfortable

### DIFF
--- a/pytorch_pfn_extras/utils/comparer.py
+++ b/pytorch_pfn_extras/utils/comparer.py
@@ -78,17 +78,20 @@ def get_default_comparer(rtol=1e-07, atol=0, equal_nan=True, msg=None):
         msg (str): Error message to be printed in case of failure.
     """
     def compare_fn(backend1, backend2, name, val1, val2):
-        err_msg = msg or f" comparing {backend1} and {backend2} in {name}"
-        torch.testing.assert_allclose(
-            # TODO select the device where
-            # the tensors will be compared?
-            val1.cpu().detach(),
-            val2.cpu().detach(),
-            rtol=rtol,
-            atol=atol,
-            equal_nan=equal_nan,
-            msg=err_msg,
-        )
+        try:
+            torch.testing.assert_allclose(
+                # TODO select the device where
+                # the tensors will be compared?
+                val1.cpu().detach(),
+                val2.cpu().detach(),
+                rtol=rtol,
+                atol=atol,
+                equal_nan=equal_nan,
+            )
+        except AssertionError as e:
+            err_msg = msg or f"Comparing '{backend1}' and '{backend2}' in '{name}'"
+            raise AssertionError(err_msg + '\n' + str(e))
+
     return compare_fn
 
 


### PR DESCRIPTION
```
AssertionError: Comparing 'cpu' and 'gpu' in 'output:a'
With rtol=1e-07 and atol=0, found 1 element(s) (out of 1) whose difference(s) exceeded the margin of error (including 0 nan comparisons). The greatest difference was 0.5 (1.0 vs. 0.5), which occurred at index 0.
```