### PR TITLE
Enforce use of `ppe.to`

### DIFF
--- a/example/mnist_trainer.py
+++ b/example/mnist_trainer.py
@@ -136,8 +136,7 @@ def main():
         options={'train_report_keys': ['loss']}
     )
 
-    if use_cuda:
-        ppe.to(model_with_loss, args.device)
+    ppe.to(model_with_loss, args.device)
 
     # Lets load the snapshot
     if args.snapshot is not None:

--- a/pytorch_pfn_extras/handler/_handler.py
+++ b/pytorch_pfn_extras/handler/_handler.py
@@ -337,6 +337,10 @@ class Handler(BaseHandler):
             load = loaders.get(sn, None)
             rt.initialize_module(sm, load, optim)
 
+        if len(self._ppe_modules) == 0:
+            raise RuntimeError(
+                'call `ppe.to(module, device)` before starting the training')
+
     def train_setup(self, trainer: Trainer, loader: Iterable[Any]) -> None:
         """A method called only once when starting a training run.
 

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_evaluator_metrics.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_evaluator_metrics.py
@@ -26,6 +26,7 @@ def test_evaluator_with_metric(device, accuracy):
         [{'x': torch.rand(20), 't': torch.rand(1)} for i in range(10)],
         batch_size=10)
 
+    ppe.to(model, device)
     evaluator = engine.create_evaluator(
         model, device=device,
         metrics=[ppe.training.metrics.AccuracyMetric('t', 'y')],

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_trainer.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_trainer.py
@@ -86,6 +86,23 @@ def test_trainer(device, path):
     trainer.run(data, data)
 
 
+def test_trainer_no_to(path):
+    model = MyModel()
+    model_with_loss = MyModelWithLossFn(model)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    data = torch.utils.data.DataLoader(
+        [(torch.rand(20,), torch.rand(10,)) for i in range(10)])
+    extensions = _make_extensions()
+
+    trainer = engine.create_trainer(
+        model_with_loss, optimizer, 20,
+        device='cpu', extensions=extensions,
+        out_dir=path,
+    )
+    with pytest.raises(RuntimeError, match="ppe.to"):
+        trainer.run(data, data)
+
+
 def test_trainer_invalid_options(path):
     device = 'cpu'
     model = MyModel()

--- a/tests/pytorch_pfn_extras_tests/utils_tests/test_comparer.py
+++ b/tests/pytorch_pfn_extras_tests/utils_tests/test_comparer.py
@@ -23,6 +23,7 @@ class Model(torch.nn.Module):
 
 def _get_trainer(device, ret_val, model_class=Model):
     model = model_class(device, ret_val)
+    ppe.to(model, device)
     optimizer = torch.optim.SGD(model.parameters(), lr=1.0)
     trainer = ppe.engine.create_trainer(model, optimizer, 1, device=device)
     return trainer
@@ -30,12 +31,14 @@ def _get_trainer(device, ret_val, model_class=Model):
 
 def _get_evaluator(device, ret_val, model_class=Model):
     model = model_class(device, ret_val)
+    ppe.to(model, device)
     evaluator = ppe.engine.create_evaluator(model, device=device)
     return evaluator
 
 
 def _get_trainer_with_evaluator(device, ret_val, model_class=Model):
     model = model_class(device, ret_val)
+    ppe.to(model, device)
     optimizer = torch.optim.SGD(model.parameters(), lr=1.0)
     evaluator = ppe.engine.create_evaluator(model, device=device)
     trainer = ppe.engine.create_trainer(
@@ -143,12 +146,14 @@ def test_comparer_kwargs(engine_fn):
     _get_trainer, _get_evaluator, _get_trainer_with_evaluator])
 def test_comparer_incompat_trigger(engine_fn):
     model_cpu = Model("cpu", 1.0)
+    ppe.to(model_cpu, 'cpu')
     optimizer_cpu = torch.optim.SGD(model_cpu.parameters(), lr=1.0)
     trainer_cpu = ppe.engine.create_trainer(
         model_cpu, optimizer_cpu, 1, device="cpu",
     )
 
     model_gpu = Model("cuda:0", 1.0)
+    ppe.to(model_gpu, 'cuda:0')
     optimizer_gpu = torch.optim.SGD(model_gpu.parameters(), lr=1.0)
     trainer_gpu = ppe.engine.create_trainer(
         model_gpu, optimizer_gpu, 1, device="cuda:0",
@@ -225,6 +230,8 @@ class ModelForComparer(torch.nn.Module):
 def test_model_comparer():
     model_cpu = ModelForComparer()
     model_gpu = ModelForComparer()
+    ppe.to(model_cpu, 'cpu')
+    ppe.to(model_gpu, 'cuda:0')
     # Make the models to have the same initial weights
     model_gpu.load_state_dict(model_cpu.state_dict())
     ppe.to(model_gpu, device='cuda:0')
@@ -249,6 +256,7 @@ def test_model_comparer():
 def test_model_comparer_invalid():
     model_cpu = ModelForComparer()
     model_gpu = ModelForComparer()
+    ppe.to(model_cpu, 'cpu')
     ppe.to(model_gpu, device='cuda:0')
 
     optimizer_cpu = torch.optim.SGD(model_cpu.parameters(), lr=0.01)


### PR DESCRIPTION
When using trainer, the user must always call `ppe.to` otherwise runtime object may not be created and cause problems later.