### PR TITLE
Call `writer.finalize()` in extensions that use the writer

### DIFF
--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -421,8 +421,7 @@ class _Snapshot(extension.Extension):
             filename, outdir, serialized_target, savefun=self._savefun)
 
     def finalize(self) -> None:
-        if hasattr(self.writer, 'finalize'):
-            self.writer.finalize()  # type: ignore
+        self.writer.finalize()  # type: ignore
 
 
 class _DistributedSnapshot(_Snapshot):

--- a/pytorch_pfn_extras/training/extensions/log_report.py
+++ b/pytorch_pfn_extras/training/extensions/log_report.py
@@ -263,5 +263,5 @@ class LogReport(extension.Extension):
         return pandas.DataFrame(self._log_looker.get())
 
     def finalize(self) -> None:
-        if self._writer is not None:
+        if self._writer is not None and hasattr(self._writer, 'finalize'):
             self._writer.finalize()

--- a/pytorch_pfn_extras/training/extensions/log_report.py
+++ b/pytorch_pfn_extras/training/extensions/log_report.py
@@ -261,3 +261,7 @@ class LogReport(extension.Extension):
                 "Need to install pandas to use `to_dataframe` method."
             )
         return pandas.DataFrame(self._log_looker.get())
+
+    def finalize(self) -> None:
+        if self._writer is not None:
+            self._writer.finalize()

--- a/pytorch_pfn_extras/training/extensions/log_report.py
+++ b/pytorch_pfn_extras/training/extensions/log_report.py
@@ -263,5 +263,5 @@ class LogReport(extension.Extension):
         return pandas.DataFrame(self._log_looker.get())
 
     def finalize(self) -> None:
-        if self._writer is not None and hasattr(self._writer, 'finalize'):
+        if self._writer is not None:
             self._writer.finalize()

--- a/pytorch_pfn_extras/training/extensions/plot_report.py
+++ b/pytorch_pfn_extras/training/extensions/plot_report.py
@@ -224,3 +224,7 @@ filename='plot.png', marker='x', grid=True)
 
     def _init_summary(self) -> None:
         self._summary = reporting.DictSummary()
+
+    def finalize(self) -> None:
+        if self._writer is not None and hasattr(self._writer, 'finalize'):
+            self._writer.finalize()

--- a/pytorch_pfn_extras/training/extensions/plot_report.py
+++ b/pytorch_pfn_extras/training/extensions/plot_report.py
@@ -226,5 +226,5 @@ filename='plot.png', marker='x', grid=True)
         self._summary = reporting.DictSummary()
 
     def finalize(self) -> None:
-        if self._writer is not None and hasattr(self._writer, 'finalize'):
+        if self._writer is not None:
             self._writer.finalize()

--- a/pytorch_pfn_extras/training/extensions/profile_report.py
+++ b/pytorch_pfn_extras/training/extensions/profile_report.py
@@ -140,3 +140,7 @@ class ProfileReport(extension.Extension):
         if hasattr(self._trigger, "load_state_dict"):
             self._trigger.load_state_dict(to_load["_trigger"])
         self._log = json.loads(to_load["_log"])
+
+    def finalize(self) -> None:
+        if self._writer is not None and hasattr(self._writer, 'finalize'):
+            self._writer.finalize()

--- a/pytorch_pfn_extras/training/extensions/profile_report.py
+++ b/pytorch_pfn_extras/training/extensions/profile_report.py
@@ -142,5 +142,5 @@ class ProfileReport(extension.Extension):
         self._log = json.loads(to_load["_log"])
 
     def finalize(self) -> None:
-        if self._writer is not None and hasattr(self._writer, 'finalize'):
+        if self._writer is not None:
             self._writer.finalize()

--- a/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
+++ b/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
@@ -409,3 +409,7 @@ grid=True)
 
         writer(self._filename, manager.out, (fig, plt),  # type: ignore
                savefun=matplotlib_savefun)
+
+    def finalize(self) -> None:
+        if self._writer is not None and hasattr(self._writer, 'finalize'):
+            self._writer.finalize()

--- a/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
+++ b/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
@@ -411,5 +411,5 @@ grid=True)
                savefun=matplotlib_savefun)
 
     def finalize(self) -> None:
-        if self._writer is not None and hasattr(self._writer, 'finalize'):
+        if self._writer is not None:
             self._writer.finalize()

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -675,6 +675,8 @@ class ExtensionsManager(_BaseExtensionsManager):
 
         if self._internal_stop_trigger(self):
             self._finalize_extensions()
+            if hasattr(self.writer, 'finalize'):
+                self.writer.finalize()
 
 
 if TYPE_CHECKING:

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -675,8 +675,7 @@ class ExtensionsManager(_BaseExtensionsManager):
 
         if self._internal_stop_trigger(self):
             self._finalize_extensions()
-            if hasattr(self.writer, 'finalize'):
-                self.writer.finalize()
+            self.writer.finalize()
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
In some writers, if close is not called before interpreter shutdown, lots of nasty things can happen as the interpreter is in an undefined state so we can see non-reproducible hangs when trying to join subprocesses, etc.

This PR assures that extensions using a writer other than the manager close it when the training loop is finished.