### PR TITLE
Fix `EOFError` on `TimeSummary` cleanup when running in subprocess

### DIFF
--- a/pytorch_pfn_extras/profiler/_time_summary.py
+++ b/pytorch_pfn_extras/profiler/_time_summary.py
@@ -82,6 +82,7 @@ class _CPUWorker:
 
     def put(self, name: str, value: float) -> None:
         assert self._queue is not None
+        assert not self._thread_exited
         self._queue.put((name, value))
 
     def _worker(self) -> None:
@@ -150,6 +151,7 @@ class _CUDAWorker:
             events: Tuple[torch.cuda.Event, torch.cuda.Event],
     ) -> None:
         assert self._queue is not None
+        assert not self._thread_exited
         self._queue.put((name, events))
 
     def _worker(self) -> None:


### PR DESCRIPTION
Fixes #377 

2 things here:

1st, python does a hard cleanup with subprocesses, so when running the cleanup the queue gets an EOFError in the worker thread before the main thread of the subprocess starts the graceful exit.

2nd, daemon threads should not be joined, so this removes the join