### PR TITLE
[onnx] Unstrip script

### DIFF
--- a/docs/source/user_guide/onnx.md
+++ b/docs/source/user_guide/onnx.md
@@ -128,6 +128,10 @@ $ ls -lh
 
 See `$ python -m pytorch_pfn_extras.onnx.strip_large_tensor -h` for help
 
+Notes:
+
+If an ONNX runtime does not support no `raw_data` tensor, `unstrip_tensor.py` will resolve. See `$ python -m pytorch_pfn_extras.onnx.unstrip_tensor -h` for help
+
 ### `pytorch_pfn_extras.onnx.export`
 
 Function with same interface like `torch.onnx.export`. Unlike `torch.onnx.export`, you can use annotation feature (described below), `strip_large_tensor_data` options, or other `torch.onnx` extensions.

--- a/pytorch_pfn_extras/onnx/unstrip_tensor.py
+++ b/pytorch_pfn_extras/onnx/unstrip_tensor.py
@@ -66,6 +66,16 @@ def _unstrip_tensor_from_path(path: Path) -> onnx.TensorProto:
 
 
 def unstrip(path: str, out_path: str = "") -> None:
+    """Unstrip ONNX models and test data(.pb).
+
+    Add tensor(raw data) to the target ONNXs (and test data).
+    Values are random following mean and variance written in meta information.
+
+    Args:
+        path (str): The target directory path, ONNX file, or Tensor (Protobuf)
+            file path.
+        out_path (str): Output path to be written.
+    """
     target_path = Path(path)
     if not target_path.exists():
         print(f"Error: the target path is not found, {path}")

--- a/pytorch_pfn_extras/onnx/unstrip_tensor.py
+++ b/pytorch_pfn_extras/onnx/unstrip_tensor.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import math
+from pathlib import Path
 
 import onnx
 import onnx.numpy_helper
@@ -11,35 +12,31 @@ from pytorch_pfn_extras.onnx import strip_large_tensor as strip
 
 def _unstrip_tensor(tensor: onnx.TensorProto) -> None:
     meta_dict = {}
-    for external_data in tensor.external_data:
-        if external_data.key != 'location':
+    meta_dict_idx = 0
+    for i, external_data in enumerate(tensor.external_data):
+        if external_data.key != "location":
             continue
         try:
             external_data_dict = json.loads(external_data.value)
-            if external_data_dict.get('type', '') == 'stripped':
+            if external_data_dict.get("type", "") == "stripped":
                 meta_dict = external_data_dict
+                meta_dict_idx = i
                 break
         except ValueError:
             continue
     if not meta_dict:
         return None
-    ave = meta_dict.get('average', None)
-    var = meta_dict.get('variance', None)
+    ave = meta_dict.get("average", None)
+    var = meta_dict.get("variance", None)
     if ave is None or var is None:
         return None
 
     np_dtype = onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[tensor.data_type]
-    dummy_arrary = numpy.random.normal(ave, math.sqrt(var), tensor.dims).astype(
-        np_dtype)
-    dummy_tensor = onnx.numpy_helper.from_array(dummy_arrary)
+    dummy_array = numpy.random.normal(ave, math.sqrt(var), tensor.dims).astype(np_dtype)
+    dummy_tensor = onnx.numpy_helper.from_array(dummy_array)
     tensor.data_location = onnx.TensorProto.DEFAULT
     tensor.raw_data = dummy_tensor.raw_data
-
-    meta_dict['type'] = "unstripped"
-    onnx.external_data_helper.set_external_data(
-        tensor, location=json.dumps(meta_dict), length=dummy_arrary.nbytes)
-
-    return None
+    del tensor.external_data[meta_dict_idx]
 
 
 def _unstrip_graph(graph: onnx.GraphProto) -> None:
@@ -50,31 +47,75 @@ def _unstrip_graph(graph: onnx.GraphProto) -> None:
 
     for node in graph.node:
         for attr in node.attribute:
-            if attr.HasField('g'):
+            if attr.HasField("g"):
                 _unstrip_graph(attr.g)
 
 
-def unstrip(onnx_path: str, out_onnx_path: str = "") -> None:
-    onnx_model = onnx.load(onnx_path, load_external_data=False)
-    _unstrip_graph(onnx_model.graph)
+def _unstrip_onnx_from_path(path: Path) -> onnx.GraphProto:
+    onnx_graph = onnx.load(path, load_external_data=False)
+    _unstrip_graph(onnx_graph.graph)
+    return onnx_graph
 
-    out_path = out_onnx_path if out_onnx_path else onnx_path
-    with open(out_path, 'wb') as fp:
-        fp.write(onnx_model.SerializeToString())
+
+def _unstrip_tensor_from_path(path: Path) -> onnx.TensorProto:
+    onnx_tensor = onnx.TensorProto()
+    with open(path, "rb") as fp:
+        onnx_tensor.ParseFromString(fp.read())
+    _unstrip_tensor(onnx_tensor)
+    return onnx_tensor
+
+
+def unstrip(path: str, out_path: str = "") -> None:
+    target_path = Path(path)
+    if not target_path.exists():
+        print(f"Error: the target path is not found, {path}")
+        return None
+    written_path = Path(out_path if out_path else path)
+
+    if target_path.is_dir():
+        onnx_model_paths = target_path.glob("*.onnx")
+        for onnx_path in onnx_model_paths:
+            written_onnx_path = written_path / onnx_path.relative_to(target_path)
+            written_onnx_path.parent.mkdir(exist_ok=True)
+            _write_onnx(_unstrip_onnx_from_path(onnx_path), written_onnx_path)
+        data_pathas = target_path.glob("test_data_set_*/*.pb")
+        for data_path in data_pathas:
+            written_tensor_path = written_path / data_path.relative_to(target_path)
+            written_tensor_path.parent.mkdir(exist_ok=True)
+            _write_tensor(_unstrip_tensor_from_path(data_path), written_tensor_path)
+        return None
+
+    ext = target_path.suffix
+    if ext == ".onnx":
+        _write_onnx(_unstrip_onnx_from_path(target_path), written_path)
+    elif ext == ".pb":
+        _write_tensor(_unstrip_tensor_from_path(target_path), written_path)
+    else:
+        print(f"Error: the target file is not supported, {path}")
+
+
+def _write_onnx(onnx_graph: onnx.GraphProto, out: Path) -> None:
+    with open(out, "wb") as fp:
+        fp.write(onnx_graph.SerializeToString())
+
+
+def _write_tensor(onnx_tensor: onnx.TensorProto, out: Path) -> None:
+    with open(out, "wb") as fp:
+        fp.write(onnx_tensor.SerializeToString())
 
 
 def _get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument('onnx_path')
-    parser.add_argument('--out_onnx_path', default="")
+    parser.add_argument("path")
+    parser.add_argument("--out_path", default="")
     return parser.parse_args()
 
 
 def _main() -> None:
     args = _get_args()
-    unstrip(args.onnx_path, args.out_onnx_path)
+    unstrip(args.path, args.out_path)
     return None
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     _main()

--- a/pytorch_pfn_extras/onnx/unstrip_tensor.py
+++ b/pytorch_pfn_extras/onnx/unstrip_tensor.py
@@ -1,0 +1,80 @@
+import argparse
+import json
+import math
+
+import onnx
+import onnx.numpy_helper
+import numpy
+
+from pytorch_pfn_extras.onnx import strip_large_tensor as strip
+
+
+def _unstrip_tensor(tensor: onnx.TensorProto) -> None:
+    meta_dict = {}
+    for external_data in tensor.external_data:
+        if external_data.key != 'location':
+            continue
+        try:
+            external_data_dict = json.loads(external_data.value)
+            if external_data_dict.get('type', '') == 'stripped':
+                meta_dict = external_data_dict
+                break
+        except ValueError:
+            continue
+    if not meta_dict:
+        return None
+    ave = meta_dict.get('average', None)
+    var = meta_dict.get('variance', None)
+    if ave is None or var is None:
+        return None
+
+    np_dtype = onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[tensor.data_type]
+    dummy_arrary = numpy.random.normal(ave, math.sqrt(var), tensor.dims).astype(
+        np_dtype)
+    dummy_tensor = onnx.numpy_helper.from_array(dummy_arrary)
+    tensor.data_location = onnx.TensorProto.DEFAULT
+    tensor.raw_data = dummy_tensor.raw_data
+
+    meta_dict['type'] = "unstripped"
+    onnx.external_data_helper.set_external_data(
+        tensor, location=json.dumps(meta_dict), length=dummy_arrary.nbytes)
+
+    return None
+
+
+def _unstrip_graph(graph: onnx.GraphProto) -> None:
+    for init in graph.initializer:
+        if not strip._is_stripped_or_set_external(init):
+            continue
+        _unstrip_tensor(init)
+
+    for node in graph.node:
+        for attr in node.attribute:
+            if attr.HasField('g'):
+                _unstrip_graph(attr.g)
+
+
+def unstrip(onnx_path: str, out_onnx_path: str = "") -> None:
+    onnx_model = onnx.load(onnx_path, load_external_data=False)
+    _unstrip_graph(onnx_model.graph)
+
+    out_path = out_onnx_path if out_onnx_path else onnx_path
+    with open(out_path, 'wb') as fp:
+        fp.write(onnx_model.SerializeToString())
+
+
+def _get_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('onnx_path')
+    parser.add_argument('--out_onnx_path', default="")
+    return parser.parse_args()
+
+
+def _main() -> None:
+    args = _get_args()
+    unstrip(args.onnx_path, args.out_onnx_path)
+    return None
+
+
+if __name__ == '__main__':
+    _main()

--- a/pytorch_pfn_extras/onnx/unstrip_tensor.py
+++ b/pytorch_pfn_extras/onnx/unstrip_tensor.py
@@ -93,6 +93,9 @@ def unstrip(path: str, out_path: str = "") -> None:
             written_tensor_path = written_path / data_path.relative_to(target_path)
             written_tensor_path.parent.mkdir(exist_ok=True)
             _write_tensor(_unstrip_tensor_from_path(data_path), written_tensor_path)
+        meta = target_path / "meta.json"
+        if meta.exists():
+            _rewrite_meta(meta, written_path)
         return None
 
     ext = target_path.suffix
@@ -112,6 +115,14 @@ def _write_onnx(onnx_graph: onnx.GraphProto, out: Path) -> None:
 def _write_tensor(onnx_tensor: onnx.TensorProto, out: Path) -> None:
     with open(out, "wb") as fp:
         fp.write(onnx_tensor.SerializeToString())
+
+
+def _rewrite_meta(meta: Path, out: Path) -> None:
+    with open(meta) as fp:
+        meta_dict = json.load(fp)
+    meta_dict["strip_large_tensor_data"] = False
+    with open(out / "meta.json", "w") as fp:
+        json.dump(meta_dict, fp, indent=2)
 
 
 def _get_args() -> argparse.Namespace:

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
@@ -1,6 +1,7 @@
 import io
 import os
 import json
+from pathlib import Path
 from packaging import version
 
 import numpy as np
@@ -17,6 +18,7 @@ from pytorch_pfn_extras.onnx import export_testcase
 from pytorch_pfn_extras.onnx import is_large_tensor
 from pytorch_pfn_extras.onnx import LARGE_TENSOR_DATA_THRESHOLD
 from pytorch_pfn_extras.onnx.strip_large_tensor import _strip_large_tensor_tool_impl
+from pytorch_pfn_extras.onnx.unstrip_tensor import unstrip
 
 
 output_dir = 'out'
@@ -307,6 +309,34 @@ def test_export_testcase_strip_large_tensor_data():
     # loading check
     onnx.load(
         os.path.join(output_dir, 'model_re.onnx'), load_external_data=False)
+
+    # unstrip test
+    unstrip_output_dir = _get_output_dir('mnist_unstripped_tensor_data')
+    unstrip(output_dir, out_path=unstrip_output_dir)
+
+    def is_unstripped_with_check(tensor):
+        if is_large_tensor(tensor, LARGE_TENSOR_DATA_THRESHOLD):
+            assert tensor.data_location == onnx.TensorProto.DEFAULT
+            return True
+        return False
+
+    onnx_paths = Path(unstrip_output_dir).glob('*.onnx')
+    check_unstripped = []
+    for onnx_path in onnx_paths:
+        onnx_model = onnx.load(onnx_path, load_external_data=False)
+        check_unstripped.extend([
+            is_unstripped_with_check(init) for init in onnx_model.graph.initializer])
+    assert len(check_unstripped) > 0
+    assert any(check_unstripped)
+
+    pb_paths = Path(unstrip_output_dir).glob('**/*.pb')
+    checked = False
+    for pb_path in pb_paths:
+        tensor = onnx.TensorProto()
+        with open(pb_path, 'rb') as f:
+            tensor.ParseFromString(f.read())
+        checked = is_unstripped_with_check(tensor) or checked
+    assert checked, 'more than one data is unstripped'
 
 
 def test_export_testcase_options():

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
@@ -338,6 +338,10 @@ def test_export_testcase_strip_large_tensor_data():
         checked = is_unstripped_with_check(tensor) or checked
     assert checked, 'more than one data is unstripped'
 
+    with open(os.path.join(unstrip_output_dir, 'meta.json')) as metaf:
+        metaj = json.load(metaf)
+        assert not metaj['strip_large_tensor_data']
+
 
 def test_export_testcase_options():
     model = Net().to('cpu')


### PR DESCRIPTION
In order to run with onnx runtimes even if the target ONNX are stripped.

```
$ python -m pytorch_pfn_extras.onnx.unstrip_tensor target.onnx
$ python -m pytorch_pfn_extras.onnx.unstrip_tensor target_dir/
```

TODO
* [x] support `*.onnx`
* [x] support `*.pb`
* [x] support directory, unstrip `model.onnx`, input/output at once
* [x] unit test
* [x] docs