### PR TITLE
Make sure to open a snapshot file in binary mode

### DIFF
--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -350,7 +350,7 @@ class _Snapshot(extension.Extension):
             assert writer is not None
             loaded_fn = _find_latest_snapshot(self.filename, outdir, writer.fs)
             if loaded_fn:
-                snapshot_file = writer.fs.open(os.path.join(outdir, loaded_fn))
+                snapshot_file = writer.fs.open(os.path.join(outdir, loaded_fn), 'rb')
                 # As described above (at ``autoload`` option),
                 # snapshot files to be autoloaded must be saved by
                 # ``save_npz`` . In order to support general format,

--- a/pytorch_pfn_extras/writing/_writer_base.py
+++ b/pytorch_pfn_extras/writing/_writer_base.py
@@ -65,7 +65,7 @@ class _PosixFileSystem(object):
     def open(
             self,
             file_path: str,
-            mode: str = 'rb',
+            mode: str = 'r',
             buffering: int = -1,
             encoding: Optional[str] = None,
             errors: Optional[str] = None,


### PR DESCRIPTION
PPE introduced file-system abstraction when saving logs/checkpoints/snapshots to arbitrary locations, with the default implementation as `ppe.writing._writer_base._PosixFileSystem`.

By default `_PosixFileSystem.open()` methods opens the file in `rb` mode. But in the local filesystem, the default mode is `'r'`.

```python
>>> open("whatever-file").mode
'r'
```
From a viewpoint of person who implements `_XXXFileSystem` similar to the `_PosixFileSystem` but for other filesystems, I think  it's better to make it behave consistently to local filesystem.

### Impact

I think the negative impact to existing codes are very limited. All the features implemented in ppe should work fine.
* snapshots: I modified to call `open(..., "rb")` in this PR.
* Logs (which are texts): It already explicitly opens the file in binary mode (cf., [log_report.py#L224](https://github.com/pfnet/pytorch-pfn-extras/blob/v0.5.4/pytorch_pfn_extras/training/extensions/log_report.py#L224) -> [_simple_writer.py#L53](https://github.com/pfnet/pytorch-pfn-extras/blob/v0.5.4/pytorch_pfn_extras/writing/_simple_writer.py#L53) -> [_writer_base.py#L266](https://github.com/pfnet/pytorch-pfn-extras/blob/v0.5.4/pytorch_pfn_extras/writing/_writer_base.py#L266))

So, if a user makes his/her own extension that saves stuff directly using `ppe.writing.Writer.fs` rather than `Writer.save()`, it may be affected.