### PR TITLE
Disable profiler by default in trainer/manager (no-compat)

### DIFF
--- a/pytorch_pfn_extras/profiler/_record.py
+++ b/pytorch_pfn_extras/profiler/_record.py
@@ -37,10 +37,10 @@ def record(
         tag: Optional[str],
         metric: Optional[str] = None,
         use_cuda: bool = False,
-        disable: bool = False,
+        enable: bool = True,
 ) -> Generator[_time_summary._ReportNotification, None, None]:
 
-    if disable:
+    if not enable:
         yield _DummyReportNotification()
         return
 
@@ -68,11 +68,11 @@ _T = TypeVar('_T')
 def record_function(
         tag: Optional[str],
         use_cuda: bool = False,
-        disable: bool = False,
+        enable: bool = True,
 ) -> Callable[[Callable[..., _T]], Callable[..., _T]]:
     def wrapper(f: Callable[..., _T]) -> Callable[..., _T]:
         def wrapped(*args: Any, **kwargs: Any) -> _T:
-            with record(tag or f.__name__, use_cuda=use_cuda, disable=disable):
+            with record(tag or f.__name__, use_cuda=use_cuda, enable=enable):
                 return f(*args, **kwargs)
 
         return wrapped
@@ -85,7 +85,7 @@ def record_iterable(
         iter: Iterable[_T],
         divide_metric: bool = False,
         use_cuda: bool = False,
-        disable: bool = False,
+        enable: bool = True,
 ) -> Iterable[_T]:
     if tag is None:
         tag = _infer_tag_name(inspect.currentframe(), depth=1)
@@ -94,7 +94,7 @@ def record_iterable(
         for i, x in enumerate(iter):
             name = f"{tag}-{i}"
             metric = name if divide_metric else tag
-            with record(name, metric, use_cuda=use_cuda, disable=disable):
+            with record(name, metric, use_cuda=use_cuda, enable=enable):
                 yield x
 
     return wrapped()

--- a/pytorch_pfn_extras/training/_trainer.py
+++ b/pytorch_pfn_extras/training/_trainer.py
@@ -46,7 +46,7 @@ class Trainer:
         else:
             self._models = models
         self._kwargs = kwargs
-        self._disable_profile = kwargs.get('disable_profile', False)
+        self._enable_profile = kwargs.get('enable_profile', False)
         self._extensions: List[  # list of (args, kwargs)
             Tuple[Tuple['training.Extension', Optional[str],
                         'TriggerLike', Optional[int]],
@@ -293,19 +293,19 @@ class Trainer:
                 with record(
                     "pytorch_pfn_extras.training.Trainer:iteration",
                     use_cuda=torch.cuda.is_available(),
-                    disable=self._disable_profile
+                    enable=self._enable_profile
                 ) as ntf0:
                     try:
                         with record(
                             "pytorch_pfn_extras.training.Trainer:get_data",
-                            disable=self._disable_profile
+                            enable=self._enable_profile
                         ):
                             x = next(loader_iter)
                     except StopIteration:
                         loader_iter = iter(train_loader)
                         with record(
                             "pytorch_pfn_extras.training.Trainer:get_data",
-                            disable=self._disable_profile
+                            enable=self._enable_profile
                         ):
                             x = next(loader_iter)
                     begin = time.time()
@@ -316,14 +316,14 @@ class Trainer:
                     with record(
                         "pytorch_pfn_extras.training.Trainer:run_iteration",
                         use_cuda=torch.cuda.is_available(),
-                        disable=self._disable_profile
+                        enable=self._enable_profile
                     ) as ntf1, \
                             self.manager.run_iteration() as iter_notifier:
                         self._observed.put(self.manager.observation)
                         with record(
                             "pytorch_pfn_extras.training.Trainer:train_step",
                             use_cuda=torch.cuda.is_available(),
-                            disable=self._disable_profile
+                            enable=self._enable_profile
                         ) as ntf2:
                             self._profile_records.put([ntf0, ntf1, ntf2])
                             self.handler.train_step(

--- a/pytorch_pfn_extras/training/_trainer.py
+++ b/pytorch_pfn_extras/training/_trainer.py
@@ -46,6 +46,7 @@ class Trainer:
         else:
             self._models = models
         self._kwargs = kwargs
+        self._disable_profile = kwargs.get('disable_profile', False)
         self._extensions: List[  # list of (args, kwargs)
             Tuple[Tuple['training.Extension', Optional[str],
                         'TriggerLike', Optional[int]],
@@ -291,17 +292,20 @@ class Trainer:
             for idx in range(train_len):
                 with record(
                     "pytorch_pfn_extras.training.Trainer:iteration",
-                    use_cuda=torch.cuda.is_available()
+                    use_cuda=torch.cuda.is_available(),
+                    disable=self._disable_profile
                 ) as ntf0:
                     try:
                         with record(
-                            "pytorch_pfn_extras.training.Trainer:get_data"
+                            "pytorch_pfn_extras.training.Trainer:get_data",
+                            disable=self._disable_profile
                         ):
                             x = next(loader_iter)
                     except StopIteration:
                         loader_iter = iter(train_loader)
                         with record(
-                            "pytorch_pfn_extras.training.Trainer:get_data"
+                            "pytorch_pfn_extras.training.Trainer:get_data",
+                            disable=self._disable_profile
                         ):
                             x = next(loader_iter)
                     begin = time.time()
@@ -311,13 +315,15 @@ class Trainer:
                     self._deferred = True
                     with record(
                         "pytorch_pfn_extras.training.Trainer:run_iteration",
-                        use_cuda=torch.cuda.is_available()
+                        use_cuda=torch.cuda.is_available(),
+                        disable=self._disable_profile
                     ) as ntf1, \
                             self.manager.run_iteration() as iter_notifier:
                         self._observed.put(self.manager.observation)
                         with record(
                             "pytorch_pfn_extras.training.Trainer:train_step",
                             use_cuda=torch.cuda.is_available(),
+                            disable=self._disable_profile
                         ) as ntf2:
                             self._profile_records.put([ntf0, ntf1, ntf2])
                             self.handler.train_step(

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -141,6 +141,7 @@ class _BaseExtensionsManager:
             writer: Optional[writing.Writer],
             stop_trigger: 'trigger_module.TriggerLike' = None,
             transform_model: _TransformModel = default_transform_model,
+            disable_profile: bool = True,
     ) -> None:
         if extensions is None:
             extensions = []
@@ -199,6 +200,7 @@ class _BaseExtensionsManager:
         for ext in extensions:
             self.extend(ext)
 
+        self._disable_profile = disable_profile
         # Initialize the writer
         self.writer.initialize(self.out)
 
@@ -486,13 +488,15 @@ class _BaseExtensionsManager:
                 else:
                     with record(
                         f'pytorch_pfn_extras.training.ExtensionsManager'
-                        f'.run_extensions:{name}'
+                        f'.run_extensions:{name}',
+                        disable=self._disable_profile,
                     ):
                         entry.extension(self)
         for name, extension in to_run:
             with record(
                 f'pytorch_pfn_extras.training.ExtensionsManager'
-                f'.run_extensions:{name}'
+                f'.run_extensions:{name}',
+                disable=self._disable_profile,
             ):
                 extension(self)
         self._model_available = True
@@ -595,6 +599,8 @@ class ExtensionsManager(_BaseExtensionsManager):
            interval trigger set to `max_epochs`
         writer (writing.Writer object): Writer that can be used by
             extensions to write data to custom filesystems.
+        disable_profile (bool): Flag to enable/disable profiling of iterations.
+            Default is `False`.
     """
 
     def __init__(
@@ -609,10 +615,11 @@ class ExtensionsManager(_BaseExtensionsManager):
             stop_trigger: 'trigger_module.TriggerLike' = None,
             writer: Optional[writing.Writer] = None,
             transform_model: _TransformModel = lambda n, x: x,
+            disable_profile: bool = True,
     ) -> None:
         super().__init__(
             models, optimizers, max_epochs, extensions,
-            out_dir, writer, stop_trigger, transform_model)
+            out_dir, writer, stop_trigger, transform_model, disable_profile)
         if iters_per_epoch < 1:
             raise ValueError(
                 'iters_per_epoch must be an integer >= 1 ({} given)'.format(
@@ -728,6 +735,8 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
         out_dir (str): Output directory (default: ``result``).
         writer (writing.Writer object): Writer that can be used by
             extensions to write data to custom filesystems.
+        disable_profile (bool): Flag to enable/disable profiling of iterations.
+            Default is `False`.
     """
     def __init__(
             self,
@@ -739,7 +748,8 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
             *,
             extensions: Optional[Sequence['extension_module.ExtensionLike']] = None,
             out_dir: str = 'result',
-            writer: Optional[writing.Writer] = None
+            writer: Optional[writing.Writer] = None,
+            disable_profile: bool = True,
     ) -> None:
         import ignite
         if not isinstance(engine, ignite.engine.Engine):
@@ -749,7 +759,8 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
             raise ImportError('Ignite version found {}. '
                               'Required is >=0.3.0'.format(ignite.__version__))
         super().__init__(
-            models, optimizers, max_epochs, extensions, out_dir, writer)
+            models, optimizers, max_epochs, extensions, out_dir, writer,
+            disable_profile=disable_profile)
         self.engine = engine
         self._start_epoch = 0  # Used to correctly restore snapshots
         self.set_ignite_handlers()

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -141,7 +141,7 @@ class _BaseExtensionsManager:
             writer: Optional[writing.Writer],
             stop_trigger: 'trigger_module.TriggerLike' = None,
             transform_model: _TransformModel = default_transform_model,
-            disable_profile: bool = True,
+            enable_profile: bool = False,
     ) -> None:
         if extensions is None:
             extensions = []
@@ -200,7 +200,7 @@ class _BaseExtensionsManager:
         for ext in extensions:
             self.extend(ext)
 
-        self._disable_profile = disable_profile
+        self._enable_profile = enable_profile
         # Initialize the writer
         self.writer.initialize(self.out)
 
@@ -489,14 +489,14 @@ class _BaseExtensionsManager:
                     with record(
                         f'pytorch_pfn_extras.training.ExtensionsManager'
                         f'.run_extensions:{name}',
-                        disable=self._disable_profile,
+                        enable=self._enable_profile,
                     ):
                         entry.extension(self)
         for name, extension in to_run:
             with record(
                 f'pytorch_pfn_extras.training.ExtensionsManager'
                 f'.run_extensions:{name}',
-                disable=self._disable_profile,
+                enable=self._enable_profile,
             ):
                 extension(self)
         self._model_available = True
@@ -599,7 +599,7 @@ class ExtensionsManager(_BaseExtensionsManager):
            interval trigger set to `max_epochs`
         writer (writing.Writer object): Writer that can be used by
             extensions to write data to custom filesystems.
-        disable_profile (bool): Flag to enable/disable profiling of iterations.
+        enable_profile (bool): Flag to enable/disable profiling of iterations.
             Default is `False`.
     """
 
@@ -615,11 +615,11 @@ class ExtensionsManager(_BaseExtensionsManager):
             stop_trigger: 'trigger_module.TriggerLike' = None,
             writer: Optional[writing.Writer] = None,
             transform_model: _TransformModel = lambda n, x: x,
-            disable_profile: bool = True,
+            enable_profile: bool = False,
     ) -> None:
         super().__init__(
             models, optimizers, max_epochs, extensions,
-            out_dir, writer, stop_trigger, transform_model, disable_profile)
+            out_dir, writer, stop_trigger, transform_model, enable_profile)
         if iters_per_epoch < 1:
             raise ValueError(
                 'iters_per_epoch must be an integer >= 1 ({} given)'.format(
@@ -735,7 +735,7 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
         out_dir (str): Output directory (default: ``result``).
         writer (writing.Writer object): Writer that can be used by
             extensions to write data to custom filesystems.
-        disable_profile (bool): Flag to enable/disable profiling of iterations.
+        enable_profile (bool): Flag to enable/disable profiling of iterations.
             Default is `False`.
     """
     def __init__(
@@ -749,7 +749,7 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
             extensions: Optional[Sequence['extension_module.ExtensionLike']] = None,
             out_dir: str = 'result',
             writer: Optional[writing.Writer] = None,
-            disable_profile: bool = True,
+            enable_profile: bool = False,
     ) -> None:
         import ignite
         if not isinstance(engine, ignite.engine.Engine):
@@ -760,7 +760,7 @@ class IgniteExtensionsManager(_BaseExtensionsManager):
                               'Required is >=0.3.0'.format(ignite.__version__))
         super().__init__(
             models, optimizers, max_epochs, extensions, out_dir, writer,
-            disable_profile=disable_profile)
+            enable_profile=enable_profile)
         self.engine = engine
         self._start_epoch = 0  # Used to correctly restore snapshots
         self.set_ignite_handlers()


### PR DESCRIPTION
The `TimeSumary` object causes problems of interop with multiprocessing because of the destruction order of threads and queues, resulting in deadlocks under some python/os configurations.

Since this feature is not widely used, we set it to `False` by default and make users to explicitly request it.

Confirmed that #496 was fixed