### PR TITLE
Fix filename format of `comparer.dump(evaluator)`

### DIFF
--- a/.flexci/linux/unittest.sh
+++ b/.flexci/linux/unittest.sh
@@ -33,8 +33,8 @@ popd
 # Comparer
 pushd example
 mkdir -p comp_dump_cpu
-python mnist_trainer.py --device cpu --epochs 1 --batch-size 1024 --deterministic --compare-dump comp_dump_cpu
-CUBLAS_WORKSPACE_CONFIG=:4096:8 python mnist_trainer.py --device cuda --epochs 1 --batch-size 1024 --deterministic --compare-with comp_dump_cpu
+python mnist_trainer.py --device cpu --epochs 2 --batch-size 1024 --deterministic --compare-dump comp_dump_cpu
+CUBLAS_WORKSPACE_CONFIG=:4096:8 python mnist_trainer.py --device cuda --epochs 2 --batch-size 1024 --deterministic --compare-with comp_dump_cpu
 popd
 
 # Publish coverage report

--- a/pytorch_pfn_extras/utils/comparer.py
+++ b/pytorch_pfn_extras/utils/comparer.py
@@ -576,7 +576,7 @@ class Comparer:
 
     def _get_filename(
             self, engine: _Engine, handler_name: str, batch_idx: int) -> str:
-        name = f'dump_{self._count}'
+        name = f'dump_{self._count:08}'
         name += '_' + type(engine).__name__
         orig_engine, _, _ = self._engines[handler_name]
         epoch = orig_engine.handler._epoch  # type: ignore


### PR DESCRIPTION
Fix filename duplication.