### PR TITLE
Add version check function for special torch package version names

### DIFF
--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Code Style
       run: |
         pip install pysen black==21.11b1 flake8==4.0.1 isort==5.10.1 mypy==0.910
-        pip install types-PyYAML
+        pip install types-PyYAML types-setuptools
         pysen run lint
 
     - name: Code Style (Examples)

--- a/pytorch_pfn_extras/__init__.py
+++ b/pytorch_pfn_extras/__init__.py
@@ -23,6 +23,6 @@ from pytorch_pfn_extras._tensor import get_xp  # NOQA
 from pytorch_pfn_extras._tensor import as_numpy_dtype  # NOQA
 from pytorch_pfn_extras._tensor import from_numpy_dtype  # NOQA
 from pytorch_pfn_extras.runtime._to import to  # NOQA
-from pytorch_pfn_extras.torch_version import is_available  # NOQA
+from pytorch_pfn_extras._torch_version import requires  # NOQA
 
 from pytorch_pfn_extras._version import __version__  # NOQA

--- a/pytorch_pfn_extras/__init__.py
+++ b/pytorch_pfn_extras/__init__.py
@@ -23,5 +23,6 @@ from pytorch_pfn_extras._tensor import get_xp  # NOQA
 from pytorch_pfn_extras._tensor import as_numpy_dtype  # NOQA
 from pytorch_pfn_extras._tensor import from_numpy_dtype  # NOQA
 from pytorch_pfn_extras.runtime._to import to  # NOQA
+from pytorch_pfn_extras.torch_version import is_available  # NOQA
 
 from pytorch_pfn_extras._version import __version__  # NOQA

--- a/pytorch_pfn_extras/_torch_version.py
+++ b/pytorch_pfn_extras/_torch_version.py
@@ -1,0 +1,7 @@
+import pkg_resources
+from packaging.version import Version
+
+
+def requires(version: str, package: str = 'torch') -> bool:
+    pkg_ver = pkg_resources.get_distribution(package).version
+    return Version(pkg_ver.split("+")[0]) >= Version(version)

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -120,7 +120,7 @@ def _export_util(
     # This is a temporal workaround until a fix is introduced in PyTorch.
     try:
         torch.onnx.utils._model_to_graph = _model_to_graph_with_value_names
-        if pytorch_pfn_extras.is_available('1.10.0'):
+        if pytorch_pfn_extras.requires('1.10.0'):
             try:
                 enable_onnx_checker = kwargs.pop('enable_onnx_checker', None)
                 return torch_export(  # type: ignore[no-untyped-call]
@@ -148,7 +148,7 @@ def _export(
     opset_ver = kwargs.get('opset_version', None)
     if opset_ver is None:
         opset_ver = _default_onnx_opset_version
-    if not pytorch_pfn_extras.is_available('1.10.0'):
+    if not pytorch_pfn_extras.requires('1.10.0'):
         strip_doc_string = kwargs.get('strip_doc_string', True)
         kwargs['strip_doc_string'] = False
     else:

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -5,12 +5,12 @@ import itertools
 import json
 import os
 import subprocess
-from packaging import version
 from typing import Any, Dict, IO, Mapping, Optional, Sequence, Tuple, Union
 import warnings
 
 import onnx
 import onnx.numpy_helper
+import pytorch_pfn_extras
 import torch
 import torch.autograd
 from torch.onnx import OperatorExportTypes
@@ -120,7 +120,7 @@ def _export_util(
     # This is a temporal workaround until a fix is introduced in PyTorch.
     try:
         torch.onnx.utils._model_to_graph = _model_to_graph_with_value_names
-        if version.Version(torch.__version__) >= version.Version('1.10.0'):
+        if pytorch_pfn_extras.is_available('1.10.0'):
             try:
                 enable_onnx_checker = kwargs.pop('enable_onnx_checker', None)
                 return torch_export(  # type: ignore[no-untyped-call]
@@ -148,7 +148,7 @@ def _export(
     opset_ver = kwargs.get('opset_version', None)
     if opset_ver is None:
         opset_ver = _default_onnx_opset_version
-    if version.Version(torch.__version__) < version.Version('1.10.0'):
+    if not pytorch_pfn_extras.is_available('1.10.0'):
         strip_doc_string = kwargs.get('strip_doc_string', True)
         kwargs['strip_doc_string'] = False
     else:

--- a/pytorch_pfn_extras/torch_version.py
+++ b/pytorch_pfn_extras/torch_version.py
@@ -1,9 +1,0 @@
-import torch
-from packaging import version
-
-
-torch_version = version.Version(torch.__version__.split("+")[0])
-
-
-def requires(version: str, *, package='torch') -> bool:
-    return torch_version >= version.Version(ver)

--- a/pytorch_pfn_extras/torch_version.py
+++ b/pytorch_pfn_extras/torch_version.py
@@ -1,0 +1,9 @@
+import torch
+from packaging import version
+
+
+torch_version = version.Version(torch.__version__.split("+")[0])
+
+
+def is_available(ver: str) -> bool:
+    return torch_version >= version.Version(ver)

--- a/pytorch_pfn_extras/torch_version.py
+++ b/pytorch_pfn_extras/torch_version.py
@@ -5,5 +5,5 @@ from packaging import version
 torch_version = version.Version(torch.__version__.split("+")[0])
 
 
-def is_available(ver: str) -> bool:
+def requires(version: str, *, package='torch') -> bool:
     return torch_version >= version.Version(ver)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
                 'development in PyTorch.',
     author='Preferred Networks, Inc.',
     license='MIT License',
-    install_requires=['numpy', 'torch', 'typing-extensions>=3.10'],
+    install_requires=['numpy', 'packaging', 'torch', 'typing-extensions>=3.10'],
     extras_require={
         'test': ['pytest'],
         'onnx': ['onnx'],

--- a/tests/pytorch_pfn_extras_tests/nn_tests/parallel_tests/test_distributed.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/parallel_tests/test_distributed.py
@@ -257,7 +257,7 @@ class TestDistributedDataParallel:
 
     @pytest.mark.parametrize('device_type', _device_types())
     @pytest.mark.skipif(
-        not pytorch_pfn_extras.is_available("1.6.0"),
+        not pytorch_pfn_extras.requires("1.6.0"),
         reason="Variable._execution_engine.queue_callback does not work "
                "with checkpointing when torch < 1.6.0")
     def test_checkpoint(self, device_type):

--- a/tests/pytorch_pfn_extras_tests/nn_tests/parallel_tests/test_distributed.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/parallel_tests/test_distributed.py
@@ -4,8 +4,8 @@ import urllib.request
 import tempfile
 
 import numpy as np
-from packaging import version
 import pytest
+import pytorch_pfn_extras
 import torch
 from torch import multiprocessing as mp
 from torch import distributed as dist
@@ -15,7 +15,6 @@ from torch.utils.checkpoint import checkpoint
 from pytorch_pfn_extras.nn.parallel import DistributedDataParallel
 
 
-torch_version = version.Version(torch.__version__)
 context = mp.get_context("spawn")
 
 
@@ -258,7 +257,7 @@ class TestDistributedDataParallel:
 
     @pytest.mark.parametrize('device_type', _device_types())
     @pytest.mark.skipif(
-        torch_version < version.Version('1.6.0'),
+        not pytorch_pfn_extras.is_available("1.6.0"),
         reason="Variable._execution_engine.queue_callback does not work "
                "with checkpointing when torch < 1.6.0")
     def test_checkpoint(self, device_type):

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_annotate.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_annotate.py
@@ -1,13 +1,13 @@
 from collections import OrderedDict
 from contextlib import suppress
 import os
-from packaging import version
 
 import numpy as np
 import onnx
 import onnx.checker
 import onnx.numpy_helper
 import pytest
+import pytorch_pfn_extras
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -19,12 +19,9 @@ from pytorch_pfn_extras.onnx import scoped_anchor
 from tests.pytorch_pfn_extras_tests.onnx_tests.test_export_testcase import _helper
 
 
-torch_version = version.Version(torch.__version__)
-
-
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_annotate_no_export():
-    if torch_version < version.Version('1.8.0'):
+    if not pytorch_pfn_extras.is_available("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):
@@ -47,7 +44,7 @@ def test_annotate_no_export():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_annotate():
-    if torch_version < version.Version('1.8.0'):
+    if not pytorch_pfn_extras.is_available("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):
@@ -102,7 +99,7 @@ def test_annotate():
 
 
 def test_apply_annotation():
-    if torch_version < version.Version('1.8.0'):
+    if not pytorch_pfn_extras.is_available("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_annotate.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_annotate.py
@@ -21,7 +21,7 @@ from tests.pytorch_pfn_extras_tests.onnx_tests.test_export_testcase import _help
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_annotate_no_export():
-    if not pytorch_pfn_extras.is_available("1.8.0"):
+    if not pytorch_pfn_extras.requires("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):
@@ -44,7 +44,7 @@ def test_annotate_no_export():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_annotate():
-    if not pytorch_pfn_extras.is_available("1.8.0"):
+    if not pytorch_pfn_extras.requires("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):
@@ -99,7 +99,7 @@ def test_annotate():
 
 
 def test_apply_annotation():
-    if not pytorch_pfn_extras.is_available("1.8.0"):
+    if not pytorch_pfn_extras.requires("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py
@@ -1,10 +1,10 @@
 import os
-from packaging import version
 
 import onnx
 import onnx.checker
 import onnx.numpy_helper
 import pytest
+import pytorch_pfn_extras
 import torch
 import torch.nn as nn
 import torch.onnx
@@ -13,12 +13,9 @@ from pytorch_pfn_extras.onnx import as_output
 from tests.pytorch_pfn_extras_tests.onnx_tests.test_export_testcase import _helper
 
 
-torch_version = version.Version(torch.__version__)
-
-
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_as_output_no_export():
-    if torch_version < version.Version('1.8.0'):
+    if not pytorch_pfn_extras.is_available("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):
@@ -41,7 +38,7 @@ def test_as_output_no_export():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_as_output():
-    if torch_version < version.Version('1.8.0'):
+    if not pytorch_pfn_extras.is_available("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):
@@ -72,7 +69,7 @@ def test_as_output():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_no_as_output():
-    if torch_version < version.Version('1.8.0'):
+    if not pytorch_pfn_extras.is_available("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py
@@ -15,7 +15,7 @@ from tests.pytorch_pfn_extras_tests.onnx_tests.test_export_testcase import _help
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_as_output_no_export():
-    if not pytorch_pfn_extras.is_available("1.8.0"):
+    if not pytorch_pfn_extras.requires("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):
@@ -38,7 +38,7 @@ def test_as_output_no_export():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_as_output():
-    if not pytorch_pfn_extras.is_available("1.8.0"):
+    if not pytorch_pfn_extras.requires("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):
@@ -69,7 +69,7 @@ def test_as_output():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_no_as_output():
-    if not pytorch_pfn_extras.is_available("1.8.0"):
+    if not pytorch_pfn_extras.requires("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
@@ -2,12 +2,12 @@ import io
 import os
 import json
 from pathlib import Path
-from packaging import version
 
 import numpy as np
 import onnx
 import onnx.numpy_helper
 import pytest
+import pytorch_pfn_extras
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -22,8 +22,6 @@ from pytorch_pfn_extras.onnx.unstrip_tensor import unstrip
 
 
 output_dir = 'out'
-
-torch_version = version.Version(torch.__version__)
 
 
 class Net(nn.Module):
@@ -113,7 +111,7 @@ def test_export_testcase_return_output():
 
     output_dir = _get_output_dir('export_filename')
 
-    if version.Version('1.6.0') <= torch_version:
+    if pytorch_pfn_extras.is_available("1.6.0"):
         with pytest.warns(UserWarning):
             (out,) = export_testcase(model, x, output_dir, return_output=True)
     else:
@@ -250,7 +248,7 @@ def test_backward_multiple_input():
 @pytest.mark.filterwarnings(
     "ignore::torch.jit.TracerWarning", "ignore::UserWarning")
 def test_export_testcase_strip_large_tensor_data():
-    if torch_version < version.Version('1.6.0'):
+    if not pytorch_pfn_extras.is_available("1.6.0"):
         pytest.skip('skip for PyTorch 1.5 or earlier')
 
     model = Net().to('cpu')
@@ -381,7 +379,7 @@ class NetWithUnusedInput(nn.Module):
 
 @pytest.mark.parametrize("keep_initializers_as_inputs", [None, True, False])
 def test_export_testcase_with_unused_input(keep_initializers_as_inputs):
-    if torch_version < version.Version('1.7.0'):
+    if not pytorch_pfn_extras.is_available("1.7.0"):
         pytest.skip('skip for PyTorch 1.6 or earlier')
 
     model = NetWithUnusedInput().to('cpu')

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
@@ -111,7 +111,7 @@ def test_export_testcase_return_output():
 
     output_dir = _get_output_dir('export_filename')
 
-    if pytorch_pfn_extras.is_available("1.6.0"):
+    if pytorch_pfn_extras.requires("1.6.0"):
         with pytest.warns(UserWarning):
             (out,) = export_testcase(model, x, output_dir, return_output=True)
     else:
@@ -248,7 +248,7 @@ def test_backward_multiple_input():
 @pytest.mark.filterwarnings(
     "ignore::torch.jit.TracerWarning", "ignore::UserWarning")
 def test_export_testcase_strip_large_tensor_data():
-    if not pytorch_pfn_extras.is_available("1.6.0"):
+    if not pytorch_pfn_extras.requires("1.6.0"):
         pytest.skip('skip for PyTorch 1.5 or earlier')
 
     model = Net().to('cpu')
@@ -379,7 +379,7 @@ class NetWithUnusedInput(nn.Module):
 
 @pytest.mark.parametrize("keep_initializers_as_inputs", [None, True, False])
 def test_export_testcase_with_unused_input(keep_initializers_as_inputs):
-    if not pytorch_pfn_extras.is_available("1.7.0"):
+    if not pytorch_pfn_extras.requires("1.7.0"):
         pytest.skip('skip for PyTorch 1.6 or earlier')
 
     model = NetWithUnusedInput().to('cpu')

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
@@ -16,7 +16,7 @@ from tests.pytorch_pfn_extras_tests.onnx_tests.test_export_testcase import _help
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_grad_no_export():
-    if not pytorch_pfn_extras.is_available("1.8.0"):
+    if not pytorch_pfn_extras.requires("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):
@@ -46,10 +46,10 @@ def test_grad_no_export():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_grad():
-    if not pytorch_pfn_extras.is_available('1.8.0'):
+    if not pytorch_pfn_extras.requires('1.8.0'):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
-    if not pytorch_pfn_extras.is_available('1.9.0') and sys.platform == 'win32':
+    if not pytorch_pfn_extras.requires('1.9.0') and sys.platform == 'win32':
         pytest.skip('ONNX grad test does not work in windows CI for torch > 1.9')
 
     class Net(nn.Module):
@@ -95,10 +95,10 @@ def test_grad():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_grad_multiple_times():
-    if not pytorch_pfn_extras.is_available("1.8.0"):
+    if not pytorch_pfn_extras.requires("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
-    if not pytorch_pfn_extras.is_available('1.9.0') and sys.platform == 'win32':
+    if not pytorch_pfn_extras.requires('1.9.0') and sys.platform == 'win32':
         pytest.skip('ONNX grad test does not work in windows CI for torch > 1.9')
 
     class Net(nn.Module):
@@ -157,10 +157,10 @@ def test_grad_multiple_times():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_grad_with_multiple_inputs():
-    if not pytorch_pfn_extras.is_available("1.8.0"):
+    if not pytorch_pfn_extras.requires("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
-    if not pytorch_pfn_extras.is_available('1.9.0') and sys.platform == 'win32':
+    if not pytorch_pfn_extras.requires('1.9.0') and sys.platform == 'win32':
         pytest.skip('ONNX grad test does not work in windows CI for torch > 1.9')
 
     class Net(nn.Module):

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
@@ -49,8 +49,8 @@ def test_grad():
     if not pytorch_pfn_extras.requires('1.8.0'):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
-    if not pytorch_pfn_extras.requires('1.9.0') and sys.platform == 'win32':
-        pytest.skip('ONNX grad test does not work in windows CI for torch > 1.9')
+    if pytorch_pfn_extras.requires('1.10.0') and sys.platform == 'win32':
+        pytest.skip('ONNX grad test does not work in windows CI for torch >= 1.10')
 
     class Net(nn.Module):
         def __init__(self):
@@ -98,8 +98,8 @@ def test_grad_multiple_times():
     if not pytorch_pfn_extras.requires("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
-    if not pytorch_pfn_extras.requires('1.9.0') and sys.platform == 'win32':
-        pytest.skip('ONNX grad test does not work in windows CI for torch > 1.9')
+    if pytorch_pfn_extras.requires('1.10.0') and sys.platform == 'win32':
+        pytest.skip('ONNX grad test does not work in windows CI for torch >= 1.10')
 
     class Net(nn.Module):
         def __init__(self):
@@ -160,8 +160,8 @@ def test_grad_with_multiple_inputs():
     if not pytorch_pfn_extras.requires("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
-    if not pytorch_pfn_extras.requires('1.9.0') and sys.platform == 'win32':
-        pytest.skip('ONNX grad test does not work in windows CI for torch > 1.9')
+    if pytorch_pfn_extras.requires('1.10.0') and sys.platform == 'win32':
+        pytest.skip('ONNX grad test does not work in windows CI for torch >= 1.10')
 
     class Net(nn.Module):
         def __init__(self):

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
@@ -1,11 +1,11 @@
 import os
-from packaging import version
 import sys
 
 import onnx
 import onnx.checker
 import onnx.numpy_helper
 import pytest
+import pytorch_pfn_extras
 import torch
 import torch.nn as nn
 import torch.onnx
@@ -14,12 +14,9 @@ from pytorch_pfn_extras.onnx import grad
 from tests.pytorch_pfn_extras_tests.onnx_tests.test_export_testcase import _helper
 
 
-torch_version = version.Version(torch.__version__)
-
-
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_grad_no_export():
-    if torch_version < version.Version('1.8.0'):
+    if not pytorch_pfn_extras.is_available("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
     class Net(nn.Module):
@@ -49,10 +46,10 @@ def test_grad_no_export():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_grad():
-    if torch_version < version.Version('1.8.0'):
+    if not pytorch_pfn_extras.is_available('1.8.0'):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
-    if torch_version > version.Version('1.9.0') and sys.platform == 'win32':
+    if not pytorch_pfn_extras.is_available('1.9.0') and sys.platform == 'win32':
         pytest.skip('ONNX grad test does not work in windows CI for torch > 1.9')
 
     class Net(nn.Module):
@@ -98,10 +95,10 @@ def test_grad():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_grad_multiple_times():
-    if torch_version < version.Version('1.8.0'):
+    if not pytorch_pfn_extras.is_available("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
-    if torch_version > version.Version('1.9.0') and sys.platform == 'win32':
+    if not pytorch_pfn_extras.is_available('1.9.0') and sys.platform == 'win32':
         pytest.skip('ONNX grad test does not work in windows CI for torch > 1.9')
 
     class Net(nn.Module):
@@ -160,10 +157,10 @@ def test_grad_multiple_times():
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_grad_with_multiple_inputs():
-    if torch_version < version.Version('1.8.0'):
+    if not pytorch_pfn_extras.is_available("1.8.0"):
         pytest.skip('skip for PyTorch 1.7 or earlier')
 
-    if torch_version > version.Version('1.9.0') and sys.platform == 'win32':
+    if not pytorch_pfn_extras.is_available('1.9.0') and sys.platform == 'win32':
         pytest.skip('ONNX grad test does not work in windows CI for torch > 1.9')
 
     class Net(nn.Module):

--- a/tests/pytorch_pfn_extras_tests/profiler_tests/test_record.py
+++ b/tests/pytorch_pfn_extras_tests/profiler_tests/test_record.py
@@ -1,5 +1,4 @@
 import os
-from packaging import version
 
 import pytest
 import torch
@@ -9,7 +8,7 @@ import pytorch_pfn_extras as ppe
 
 _profiler_available = (
     os.name != 'nt'
-    or version.Version(torch.__version__) >= version.Version("1.9")
+    or ppe.is_available("1.9")
 )
 
 

--- a/tests/pytorch_pfn_extras_tests/profiler_tests/test_record.py
+++ b/tests/pytorch_pfn_extras_tests/profiler_tests/test_record.py
@@ -8,7 +8,7 @@ import pytorch_pfn_extras as ppe
 
 _profiler_available = (
     os.name != 'nt'
-    or ppe.is_available("1.9")
+    or ppe.requires("1.9")
 )
 
 


### PR DESCRIPTION
Rel https://github.com/pfnet/pytorch-pfn-extras/pull/484
When using torch with version names like `1.9.0+cpu+clang10`, `version.Version` will fail to parse it so this would be a workaround for special package version names