### PR TITLE
Fix test failures in pytest7

### DIFF
--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_extended_sequential.py
@@ -1,6 +1,7 @@
 import unittest
 import pytest
 import functools
+import warnings
 
 import numpy
 import torch
@@ -220,7 +221,8 @@ class UserDefinedLayerWithBuffer(nn.Module):
 def test_no_warning_when_repeat(module):
     model = ppe.nn.ExtendedSequential(module())
     # no warnings are raised on these modules
-    with pytest.warns(None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         model.repeat(2)
 
 

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_evaluator_metrics.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_evaluator_metrics.py
@@ -36,7 +36,7 @@ def test_evaluator_with_metric(device, accuracy):
     observation = {}
     with reporter.scope(observation):
         evaluator.run(data)
-    assert pytest.approx(observation['val/accuracy'], accuracy)
+    assert pytest.approx(observation['val/accuracy']) == accuracy
 
 
 class AsyncResult(ppe.handler.DeferredResult):
@@ -94,4 +94,4 @@ def test_evaluator_async(accuracy):
     observation = {}
     with reporter.scope(observation):
         evaluator.run(data)
-    assert pytest.approx(observation['val/accuracy'], accuracy)
+    assert pytest.approx(observation['val/accuracy']) == accuracy


### PR DESCRIPTION
- Fail logs: https://ci.preferred.jp/pytorch-pfn-extras.torch110-linux/94143/#L939
- Changes for `pytest.warns(None)`: https://docs.pytest.org/en/7.0.x/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests