### PR TITLE
Fix version check for versions with '-' splitter

### DIFF
--- a/pytorch_pfn_extras/_torch_version.py
+++ b/pytorch_pfn_extras/_torch_version.py
@@ -4,4 +4,4 @@ from packaging.version import Version
 
 def requires(version: str, package: str = 'torch') -> bool:
     pkg_ver = pkg_resources.get_distribution(package).version
-    return Version(pkg_ver.split("+")[0]) >= Version(version)
+    return Version(pkg_ver.split("+")[0].split("-")[0]) >= Version(version)


### PR DESCRIPTION
For example `torch.__version__` returns `1.9.0+cu102` but in some env `pkg_resources.get_distribution(package).version` returns `1.9.0-cu102`