### PR TITLE
Add a extension to post to Slack

### DIFF
--- a/.flexci/linux/build_and_push.sh
+++ b/.flexci/linux/build_and_push.sh
@@ -9,7 +9,7 @@ fi
 
 TEST_PIP_PACKAGES="
 matplotlib tensorboard ipython ipywidgets pandas optuna onnxruntime
-pytest flake8 pysen[lint] pytest-cov
+pytest flake8 pysen[lint] pytest-cov slack_sdk
 "
 
 docker_build_and_push() {

--- a/.flexci/linux/build_and_push.sh
+++ b/.flexci/linux/build_and_push.sh
@@ -9,7 +9,7 @@ fi
 
 TEST_PIP_PACKAGES="
 matplotlib tensorboard ipython ipywidgets pandas optuna onnxruntime
-pytest flake8 pysen[lint] pytest-cov slack_sdk requests
+pytest flake8 pysen[lint] pytest-cov slack_sdk
 "
 
 docker_build_and_push() {

--- a/.flexci/linux/build_and_push.sh
+++ b/.flexci/linux/build_and_push.sh
@@ -9,7 +9,7 @@ fi
 
 TEST_PIP_PACKAGES="
 matplotlib tensorboard ipython ipywidgets pandas optuna onnxruntime
-pytest flake8 pysen[lint] pytest-cov slack_sdk
+pytest flake8 pysen[lint] pytest-cov slack_sdk requests
 "
 
 docker_build_and_push() {

--- a/.flexci/windows/test.ps1
+++ b/.flexci/windows/test.ps1
@@ -50,7 +50,7 @@ if ($test -eq "torch18") {
 RunOrDie python -V
 
 # Install common requirements
-RunOrDie python -m pip install pytorch-ignite pytest flake8 matplotlib tensorboard onnx ipython ipywidgets pandas optuna cupy-cuda102 onnxruntime slack_sdk requests
+RunOrDie python -m pip install pytorch-ignite pytest flake8 matplotlib tensorboard onnx ipython ipywidgets pandas optuna cupy-cuda102 onnxruntime slack_sdk
 RunOrDie python -m pip list
 
 # Install

--- a/.flexci/windows/test.ps1
+++ b/.flexci/windows/test.ps1
@@ -50,7 +50,7 @@ if ($test -eq "torch18") {
 RunOrDie python -V
 
 # Install common requirements
-RunOrDie python -m pip install pytorch-ignite pytest flake8 matplotlib tensorboard onnx ipython ipywidgets pandas optuna cupy-cuda102 onnxruntime
+RunOrDie python -m pip install pytorch-ignite pytest flake8 matplotlib tensorboard onnx ipython ipywidgets pandas optuna cupy-cuda102 onnxruntime slack_sdk
 RunOrDie python -m pip list
 
 # Install

--- a/.flexci/windows/test.ps1
+++ b/.flexci/windows/test.ps1
@@ -50,7 +50,7 @@ if ($test -eq "torch18") {
 RunOrDie python -V
 
 # Install common requirements
-RunOrDie python -m pip install pytorch-ignite pytest flake8 matplotlib tensorboard onnx ipython ipywidgets pandas optuna cupy-cuda102 onnxruntime slack_sdk
+RunOrDie python -m pip install pytorch-ignite pytest flake8 matplotlib tensorboard onnx ipython ipywidgets pandas optuna cupy-cuda102 onnxruntime slack_sdk requests
 RunOrDie python -m pip list
 
 # Install

--- a/example/mnist.py
+++ b/example/mnist.py
@@ -81,6 +81,8 @@ def main():
                         help='For Saving the current Model')
     parser.add_argument('--snapshot', type=str, default=None,
                         help='path to snapshot file')
+    parser.add_argument('--slack', type=str, default=None,
+                        help='post to the specified Slack channel')
     args = parser.parse_args()
     use_cuda = args.cuda and torch.cuda.is_available()
 
@@ -136,6 +138,14 @@ def main():
                                 'val/loss', 'val/acc']),
         extensions.snapshot(),
     ]
+
+    if args.slack is not None:
+        my_extensions.append(extensions.Slack(
+            channel=args.slack,
+            msg='Epoch #{manager.epoch}: val/loss : {val/loss}',
+            filenames=['result/statistics.png'],
+        ))
+
     # Custom stop triggers can be added to the manager and
     # their status accessed through `manager.stop_trigger`
     trigger = None

--- a/pytorch_pfn_extras/training/extensions/__init__.py
+++ b/pytorch_pfn_extras/training/extensions/__init__.py
@@ -13,6 +13,7 @@ from pytorch_pfn_extras.training.extensions.profile_report import ProfileReport 
 from pytorch_pfn_extras.training.extensions.parameter_statistics import ParameterStatistics  # NOQA
 from pytorch_pfn_extras.training.extensions.plot_report import PlotReport  # NOQA
 from pytorch_pfn_extras.training.extensions.profile_report import ProfileReport  # NOQA
+from pytorch_pfn_extras.training.extensions.slack import Slack  # NOQA
 from pytorch_pfn_extras.training.extensions.value_observation import observe_lr  # NOQA
 from pytorch_pfn_extras.training.extensions.value_observation import observe_value  # NOQA
 from pytorch_pfn_extras.training.extensions.variable_statistics_plot import VariableStatisticsPlot  # NOQA

--- a/pytorch_pfn_extras/training/extensions/__init__.py
+++ b/pytorch_pfn_extras/training/extensions/__init__.py
@@ -13,7 +13,7 @@ from pytorch_pfn_extras.training.extensions.profile_report import ProfileReport 
 from pytorch_pfn_extras.training.extensions.parameter_statistics import ParameterStatistics  # NOQA
 from pytorch_pfn_extras.training.extensions.plot_report import PlotReport  # NOQA
 from pytorch_pfn_extras.training.extensions.profile_report import ProfileReport  # NOQA
-from pytorch_pfn_extras.training.extensions.slack import Slack  # NOQA
+from pytorch_pfn_extras.training.extensions.slack import Slack, SlackWebhook  # NOQA
 from pytorch_pfn_extras.training.extensions.value_observation import observe_lr  # NOQA
 from pytorch_pfn_extras.training.extensions.value_observation import observe_value  # NOQA
 from pytorch_pfn_extras.training.extensions.variable_statistics_plot import VariableStatisticsPlot  # NOQA

--- a/pytorch_pfn_extras/training/extensions/slack.py
+++ b/pytorch_pfn_extras/training/extensions/slack.py
@@ -96,6 +96,9 @@ class Slack(extension.Extension):
     def __call__(self, manager: ExtensionsManagerProtocol) -> None:
         if not _slack_sdk_available:
             return
+
+        assert self._client is not None
+
         observation = manager.observation
 
         if callable(self._text):

--- a/pytorch_pfn_extras/training/extensions/slack.py
+++ b/pytorch_pfn_extras/training/extensions/slack.py
@@ -1,0 +1,122 @@
+import os
+import warnings
+
+from typing import Any, Callable, List, Optional, Union
+
+from pytorch_pfn_extras.training import extension
+from pytorch_pfn_extras.training._manager_protocol import ExtensionsManagerProtocol
+
+
+try:
+    import slack_sdk
+    _slack_sdk_available = True
+except ImportError:
+    _slack_sdk_available = False
+
+
+class Slack(extension.Extension):
+    """An extension to communicate with Slack.
+
+    This extension receives a ``text_template`` argument that contains
+    placeholders that will be populated with ``manager`` or ``manager.observation``
+    fields, and custom objects such as ``context_object``.
+
+    For example. `text_template = "Loss {loss} for iteration {.iteration}"`
+    will be populated as `text_template.format(manager, context_object, **observation)`
+    retrieving the ``loss`` value from the ``observation`` and ``.iteration`` from
+    the manager object. Instead of string, a callable object taking the
+    ``ExtensionsManager``, ``context_object`` and the observation dictionary can
+    be used instead. The same rules apply for the ``filenames_template`` argument.
+
+    Args:
+        channel_id (str): The channel where messages or files will be sent.
+        text_template (str or callable): Template for sending the message.
+            It can be a string to be formatted using ``.format`` or a callable
+            that returns a string. In both cases, `manager`, the current
+            observation dict and the context object are used to look up
+            values of interest.
+        filenames_template (list of str or callable): list of files that will
+            be uploaded to slack, these are string templates that can take
+            values in the same way as ``text_template``. Optional.
+        use_threads (bool): If subsequent calls of this extensions should be
+            posted as a thread of the original message or not.
+            Default is ``False``.
+        context_object (object): Custom object that contains data used to
+            format the text or the filenames. Optional, default is ``None``.
+        token (str): Token for the slack api, if ``None`` the environment
+            variable ``SLACK_TOKEN`` will be used. Ignored if ``client`` is
+            supplied. Optional, default is ``None``.
+        client (slack_sdk.WebClient): In case that there is an already created
+            slack client in the application, allows to directly use it.
+            Optional, default is ``None``
+    """
+    def __init__(
+        self,
+        channel_id: str,
+        text_template: Union[
+            str, Callable[[ExtensionsManagerProtocol, Any, dict], str]
+        ],
+        filenames_template: Optional[
+            List[
+                Union[
+                    str, Callable[[ExtensionsManagerProtocol, Any, dict], str]
+                ]
+            ]
+        ] = None,
+        use_threads: bool = False,
+        context_object: Optional[object] = None,
+        token: Optional[str] = None,
+        client: Optional[slack_sdk.WebClient] = None,
+    ) -> None:
+        if not _slack_sdk_available:
+            warnings.warn(
+                '`slack_api` package is unavailable. '
+                'Slack will do nothing.')
+            return
+
+        self._client = client
+        if client is None:
+            if token is None:
+                token = os.environ.get('SLACK_TOKEN', None)
+            if token is None:
+                raise RuntimeError(
+                    '`token` is needed for communicating with slack')
+            self._client = slack_sdk.WebClient(token=token)
+
+        # values in current observation or log report to send to slack
+        self._text = text_template
+        if filenames_template is None:
+            filenames_template = []
+        self._filenames = filenames_template
+        self._context = context_object
+        self._channel_id = channel_id
+
+    def __call__(self, manager: ExtensionsManagerProtocol) -> None:
+        if not _slack_sdk_available:
+            # Warning
+            return
+        observation = manager.observation
+
+        if callable(self._text):
+            text = self._text(manager, self._context, observation)
+        else:
+            text = self._text.format(manager, self._context, **observation)
+
+        response = self._client.chat_postMessage(
+            channel=self._channel_id,
+            text=text
+        )
+        assert response.get("ok")  # type: ignore[no-untyped-call]
+        self._ts = response.get("ts")  # type: ignore[no-untyped-call]
+        for filename in self._filenames:
+            if callable(filename):
+                filename = filename(manager, self._context, observation)
+            else:
+                filename = filename.format(
+                    manager, self._context, **observation)
+            response = self._client.files_upload(
+                channels=self._channel_id,
+                file=filename,
+                thread_ts=self._ts,
+            )
+            assert response.get("ok")  # type: ignore[no-untyped-call]

--- a/pytorch_pfn_extras/training/extensions/slack.py
+++ b/pytorch_pfn_extras/training/extensions/slack.py
@@ -9,8 +9,7 @@ import traceback
 import types
 import warnings
 
-from typing import Any, Callable, Dict, List, Optional, Union
-from typing import TYPE_CHECKING, cast
+from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 
 from pytorch_pfn_extras.training import extension
 from pytorch_pfn_extras.training import trigger as trigger_module
@@ -72,8 +71,7 @@ class Slack(extension.Extension):
 
     Args:
         channel (str): The channel where messages or files will be sent.
-            This can be the channel name if starts with '#' or the channel id
-            otherwise.
+            This can be the channel name or the channel id.
         msg (str or callable): Template for sending the message.
             It can be a string to be formatted using ``.format`` or a callable
             that returns a string. In both cases, `manager`, the current
@@ -168,26 +166,12 @@ class Slack(extension.Extension):
             filenames = []
         self._filenames = filenames
         self._context = context_object
-        self._channel_id = self._get_channel_id(channel)
+        self._channel_id = channel
         self._thread = thread
         self._ts = None
         self._upload_trigger = None
         if upload_trigger is not None:
             self._upload_trigger = trigger_module.get_trigger(upload_trigger)
-
-    def _get_channel_id(self, channel: str) -> str:
-        if channel[0] != '#':
-            return channel
-        channel_ids = {}
-        assert self._client is not None
-        # TODO enable pagination
-        response = self._client.conversations_list()
-        for c in response['channels']:
-            channel_ids[c['name']] = c['id']
-        channel_name = channel_ids.get(channel[1:], None)
-        if channel_name is None:
-            raise RuntimeError(f'Couldn\'t find channel {channel}')
-        return cast(str, channel_name)
 
     def _upload_files(self, manager:ExtensionsManagerProtocol) -> List[str]:
         observation = manager.observation

--- a/pytorch_pfn_extras/training/extensions/slack.py
+++ b/pytorch_pfn_extras/training/extensions/slack.py
@@ -8,7 +8,7 @@ from pytorch_pfn_extras.training import extension
 from pytorch_pfn_extras.training._manager_protocol import ExtensionsManagerProtocol
 
 try:
-    import requests
+    import requests  # type: ignore[import]
     _requests_available = True
 except ImportError:
     _requests_available = False

--- a/pytorch_pfn_extras/training/extensions/slack.py
+++ b/pytorch_pfn_extras/training/extensions/slack.py
@@ -66,7 +66,7 @@ class Slack(extension.Extension):
         use_threads: bool = False,
         context_object: Optional[object] = None,
         token: Optional[str] = None,
-        client: Optional[slack_sdk.WebClient] = None,
+        client: Optional[Any] = None,  # slack_sdk.WebClient, Any to avoid mypy errors
     ) -> None:
         if not _slack_sdk_available:
             warnings.warn(

--- a/pytorch_pfn_extras/training/extensions/slack.py
+++ b/pytorch_pfn_extras/training/extensions/slack.py
@@ -7,7 +7,7 @@ import sys
 import socket
 import warnings
 
-from typing import Any, Callable, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 
 from pytorch_pfn_extras.training import extension
 from pytorch_pfn_extras.training._manager_protocol import ExtensionsManagerProtocol
@@ -27,7 +27,7 @@ except ImportError:
 _identity = f'{getpass.getuser()}@{socket.gethostname()} [PID {os.getpid()}]'
 
 
-def _default_start_msg(*args, **kwargs) -> str:
+def _default_start_msg(m: ExtensionsManagerProtocol, c: Any, o: Dict[Any, Any]) -> str:
     return f'''**Training started! {_identity}**
 Command: `{shlex.quote(' '.join(sys.argv))}`
 '''
@@ -129,11 +129,11 @@ class Slack(extension.Extension):
         if start_msg is None:
             self._start_msg = _default_start_msg
         else:
-            self._start_msg = start_msg
+            self._start_msg = start_msg  # type: ignore[assignment]
         if end_msg is None:
             self._end_msg = _default_end_msg
         else:
-            self._end_msg = end_msg
+            self._end_msg = end_msg  # type: ignore[assignment]
         if filenames is None:
             filenames = []
         self._filenames = filenames
@@ -188,11 +188,11 @@ class Slack(extension.Extension):
             assert response.get("ok")  # type: ignore[no-untyped-call]
 
     def initialize(self, manager: ExtensionsManagerProtocol) -> None:
-        if _slack_sdk_available and self._start_msg != '':
+        if _slack_sdk_available and self._start_msg != '':  # type: ignore[comparison-overlap]
             self._send_message(manager, self._start_msg)
 
     def finalize(self, manager: ExtensionsManagerProtocol) -> None:
-        if _slack_sdk_available and self._end_msg != '':
+        if _slack_sdk_available and self._end_msg != '':  # type: ignore[comparison-overlap]
             self._send_message(manager, self._end_msg)
 
     def __call__(self, manager: ExtensionsManagerProtocol) -> None:
@@ -255,11 +255,11 @@ class SlackWebhook(extension.Extension):
         if start_msg is None:
             self._start_msg = _default_start_msg
         else:
-            self._start_msg = start_msg
+            self._start_msg = start_msg  # type: ignore[assignment]
         if end_msg is None:
             self._end_msg = _default_end_msg
         else:
-            self._end_msg = end_msg
+            self._end_msg = end_msg  # type: ignore[assignment]
         self._context = context_object
 
     def _send_message(
@@ -289,11 +289,11 @@ class SlackWebhook(extension.Extension):
             urllib.request.urlopen(request)
 
     def initialize(self, manager: ExtensionsManagerProtocol) -> None:
-        if _slack_sdk_available and self._start_msg != '':
+        if _slack_sdk_available and self._start_msg != '':  # type: ignore[comparison-overlap]
             self._send_message(manager, self._start_msg)
 
     def finalize(self, manager: ExtensionsManagerProtocol) -> None:
-        if _slack_sdk_available and self._end_msg != '':
+        if _slack_sdk_available and self._end_msg != '':  # type: ignore[comparison-overlap]
             self._send_message(manager, self._end_msg)
 
     def __call__(self, manager: ExtensionsManagerProtocol) -> None:

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_slack.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_slack.py
@@ -31,8 +31,7 @@ class TestSlack:
             return_value={'ok': True, 'ts': t_ts},
         ) as patched:
             with manager.run_iteration():
-                assert patched.call_args.kwargs["text"].startswith(
-                    '**Training started')
+                assert 'Training started' in patched.call_args.kwargs["text"]
                 ppe.reporting.report({'loss': 0.5})
             patched.assert_called_with(
                 channel='0', text='It 1 loss: 0.5', thread_ts=t_ts
@@ -48,8 +47,7 @@ class TestSlack:
                 ppe.reporting.report({'loss': 0.75})
             with manager.run_iteration():
                 ppe.reporting.report({'loss': 0.75})
-            assert patched.call_args.kwargs["text"].startswith(
-                '**Training finish')
+            assert 'Training finish' in patched.call_args.kwargs["text"]
 
     def test_post_message_on_error(self):
         manager = self._get_manager()
@@ -68,8 +66,7 @@ class TestSlack:
                 with manager.run_iteration():
                     raise RuntimeError('error')
             except RuntimeError:
-                assert patched.call_args.kwargs["text"].startswith(
-                    '**Error during')
+                assert 'Error during' in patched.call_args.kwargs["text"]
 
     def test_post_message_webhook(self):
         manager = self._get_manager()
@@ -141,8 +138,8 @@ class TestSlack:
             with manager.run_iteration():
                 pass
             upload.assert_has_calls([
-                mock.call(file='file_1', thread_ts=1),
-                mock.call(file='result/abc', thread_ts=1),
+                mock.call(file='file_1'),
+                mock.call(file='result/abc'),
             ], any_order=True)
 
     def test_invalid(self):

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_slack.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_slack.py
@@ -19,7 +19,8 @@ class TestSlack:
         manager = self._get_manager()
         message = 'It {.iteration} loss: {loss}'
         extension = ppe.training.extensions.Slack(
-            '0', message, token='123', use_threads=use_threads)
+            '0', message, token='123', use_threads=use_threads,
+            trigger=(1, 'iteration'))
 
         t_ts = None
         if use_threads:
@@ -45,7 +46,7 @@ class TestSlack:
         manager = self._get_manager()
         message = 'It {.iteration} loss: {loss}'
         extension = ppe.training.extensions.Slack(
-            '0', message, webhook_url="http://test")
+            '0', message, webhook_url="http://test", trigger=(1, 'iteration'))
 
         manager.extend(extension, trigger=(1, 'iteration'))
         response = requests.Response()
@@ -80,7 +81,7 @@ class TestSlack:
         manager = self._get_manager()
         context = _CustomContext()
         extension = ppe.training.extensions.Slack(
-            '0', message, context_object=context, token='123')
+            '0', message, context_object=context, token='123', trigger=(1, 'iteration'))
         manager.extend(extension, trigger=(1, 'iteration'))
         with mock.patch(
             'slack_sdk.WebClient.chat_postMessage',
@@ -104,7 +105,8 @@ class TestSlack:
         manager = self._get_manager()
         message = 'it: {.iteration}'
         filenames = ['file_{.iteration}', '{._out}/abc']
-        extension = ppe.training.extensions.Slack('0', message, filenames, token='123')
+        extension = ppe.training.extensions.Slack(
+            '0', message, filenames_template=filenames, token='123', trigger=(1, 'iteration'))
         manager.extend(extension, trigger=(1, 'iteration'))
 
         with mock.patch(
@@ -123,13 +125,16 @@ class TestSlack:
         filenames = ['file_{.iteration}', '{._out}/abc']
         with pytest.raises(ValueError, match='used to post files'):
             ppe.training.extensions.Slack(
-                '0', message, filenames, webhook_url='123')
+                '0', message, None, None, filenames, webhook_url='123', trigger=(1, 'iteration'))
         with pytest.raises(ValueError, match='client and token'):
             ppe.training.extensions.Slack(
-                '0', message, filenames, webhook_url='123', client=1)
+                '0', message, None, None, filenames, webhook_url='123',
+                client=1, trigger=(1, 'iteration'))
         with pytest.raises(ValueError, match='client and token'):
             ppe.training.extensions.Slack(
-                '0', message, filenames, webhook_url='123', token=1)
+                '0', message, None, None, filenames, webhook_url='123',
+                token=1, trigger=(1, 'iteration'))
         with pytest.raises(ValueError, match='client and token'):
             ppe.training.extensions.Slack(
-                '0', message, filenames, webhook_url='123', client=1, token=1)
+                '0', message, None, None, filenames, webhook_url='123',
+                client=1, token=1, trigger=(1, 'iteration'))

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_slack.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_slack.py
@@ -5,6 +5,10 @@ import pytest
 import pytorch_pfn_extras as ppe
 
 
+@pytest.mark.skipif(
+    not ppe.training.extensions.slack._slack_sdk_available,
+    reason="Slack SDK not installed"
+)
 class TestSlack:
     def _get_manager(self):
         return ppe.training.ExtensionsManager({}, [], 100, iters_per_epoch=5)

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_slack.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_slack.py
@@ -1,0 +1,90 @@
+from unittest import mock
+
+import pytest
+
+import pytorch_pfn_extras as ppe
+
+
+class TestSlack:
+    def _get_manager(self):
+        return ppe.training.ExtensionsManager({}, [], 100, iters_per_epoch=5)
+
+    @pytest.mark.parametrize('use_threads',[False, True])
+    def test_post_message(self, use_threads):
+        manager = self._get_manager()
+        message = 'It {.iteration} loss: {loss}'
+        extension = ppe.training.extensions.Slack(
+            '0', message, token='123', use_threads=use_threads)
+
+        t_ts = None
+        if use_threads:
+            t_ts = 1
+
+        manager.extend(extension, trigger=(1, 'iteration'))
+        with mock.patch(
+            'slack_sdk.WebClient.chat_postMessage',
+            return_value={'ok': True, 'ts': t_ts},
+        ) as patched:
+            with manager.run_iteration():
+                ppe.reporting.report({'loss': 0.5})
+            patched.assert_called_with(
+                channel='0', text='It 1 loss: 0.5', thread_ts=None
+            )
+            with manager.run_iteration():
+                ppe.reporting.report({'loss': 0.75})
+            patched.assert_called_with(
+                channel='0', text='It 2 loss: 0.75', thread_ts=t_ts
+            )
+
+    @pytest.mark.parametrize(
+        'message',
+        [
+            'It {.iteration} loss: {loss} custom: {.foo}',
+            lambda m,c,o: 'It {.iteration} loss: {loss} custom: {.foo}'.format(m,c, **o)
+        ]
+    )
+    def test_post_message_context(self, message):
+        class _CustomContext:
+            def __init__(self):
+                self.foo = 'bar'
+
+        manager = self._get_manager()
+        context = _CustomContext()
+        extension = ppe.training.extensions.Slack(
+            '0', message, context_object=context, token='123')
+        manager.extend(extension, trigger=(1, 'iteration'))
+        with mock.patch(
+            'slack_sdk.WebClient.chat_postMessage',
+            return_value={'ok': True, 'ts': 1},
+        ) as patched:
+            with manager.run_iteration():
+                ppe.reporting.report({'loss': 0.5})
+            patched.assert_called_with(
+                channel='0', text='It 1 loss: 0.5 custom: bar',
+                thread_ts=None
+            )
+            context.foo = 'test'
+            with manager.run_iteration():
+                ppe.reporting.report({'loss': 0.75})
+            patched.assert_called_with(
+                channel='0', text='It 2 loss: 0.75 custom: test',
+                thread_ts=None
+            )
+
+    def test_post_message_files(self):
+        manager = self._get_manager()
+        message = 'it: {.iteration}'
+        filenames = ['file_{.iteration}', '{._out}/abc']
+        extension = ppe.training.extensions.Slack('0', message, filenames, token='123')
+        manager.extend(extension, trigger=(1, 'iteration'))
+
+        with mock.patch(
+            'slack_sdk.WebClient.chat_postMessage',
+            return_value={'ok': True, 'ts': 1},
+        ), mock.patch('slack_sdk.WebClient.files_upload') as upload:
+            with manager.run_iteration():
+                pass
+            upload.assert_has_calls([
+                mock.call(channels=r'0', file='file_1', thread_ts=None),
+                mock.call(channels=r'0', file='result/abc', thread_ts=None),
+            ], any_order=True)


### PR DESCRIPTION
This extension allows posting messages that can access values in `.manager` the current observation of the reporter and values in a custom object (like models, or other extension).

Also it is possible to upload files, such as loss plot or even snapshots.

Closes #38 

Image was updated
https://ci.preferred.jp/pytorch-pfn-extras.prep-linux/96220/