### PR TITLE
pfto: Fix onnx export of torch.cat

### DIFF
--- a/pytorch_pfn_extras/onnx/pfto_exporter/export.py
+++ b/pytorch_pfn_extras/onnx/pfto_exporter/export.py
@@ -511,6 +511,7 @@ class _Exporter(_ExporterOptions):
                 if i in start_vals:
                     continue
                 ret.add(i.node())
+                start_vals.add(i)
                 target_vals.extend(list(i.node().inputs()))
             return list(ret)
 

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export.py
@@ -138,3 +138,21 @@ def test_dynamic_axes():
     assert model.graph.input[1].type.tensor_type.shape.dim[0].dim_param == "y_dynamic_axes_1"
     assert model.graph.input[1].type.tensor_type.shape.dim[1].dim_param == "y_dynamic_axes_2"
     assert model.graph.output[0].type.tensor_type.shape.dim[0].dim_param == "out_dynamic_axes_1"
+
+
+@pytest.mark.filterwarnings("ignore:No input args:UserWarning")
+def test_concat():
+    model: onnx.ModelProto = run_model_test(
+        AnyModel(lambda m: torch.cat((m.x, m.y), axis=0),
+                 {"x": _aranges(2, 3, 2), "y": _aranges(3, 3, 2)}),
+        (),
+    )
+    assert len(model.graph.node) == 1
+    assert model.graph.node[0].op_type == "Concat"
+    model = run_model_test(
+        AnyModel(lambda m: torch.cat((m.x, m.y), axis=1),
+                 {"x": _aranges(2, 3, 2), "y": _aranges(2, 3, 2)}),
+        (),
+    )
+    assert len(model.graph.node) == 1
+    assert model.graph.node[0].op_type == "Concat"


### PR DESCRIPTION
Previous: `onnx::ListConstruct` (prim::ListConstruct) -> `onnx::ConcatFromSequence` (aten::cat)
Now: `onnx::Concat` only