### PR TITLE
Fix the type annotation of LogReport.log

### DIFF
--- a/pytorch_pfn_extras/training/extensions/log_report.py
+++ b/pytorch_pfn_extras/training/extensions/log_report.py
@@ -230,7 +230,7 @@ class LogReport(extension.Extension):
             self._init_summary()
 
     @property
-    def log(self) -> List[str]:
+    def log(self) -> List[Mapping[str, Any]]:
         """The current list of observation dictionaries."""
         return self._log_looker.get()
 


### PR DESCRIPTION
The type annotation in LogReport.log seems to be one of the following.
 - List[Any]
 - List[Mapping[str, Any]]
 - List[Dict[str, Any ]]
 - Sequence[Mapping[str, Any]]

I chose List[Mapping[str, Any]], but would like to know if something different is better.