### PR TITLE
Respect types of previous items when setting config via args

### DIFF
--- a/pytorch_pfn_extras/config.py
+++ b/pytorch_pfn_extras/config.py
@@ -142,6 +142,15 @@ class Config(object):
         for k, v in args:
             n_k, c_k = _parse_key(k, ())[:2]
             if (n_k, c_k) in self._cache:
+                if (
+                    isinstance(self._cache[(n_k, c_k)], bool)
+                    and isinstance(v, str)
+                ):
+                    if not v.lower() in ("true", "false"):
+                        raise ValueError(
+                            f'bool should be true/false. Found {v}'
+                        )
+                    v = v.lower() == "true"
                 self._cache[(n_k, c_k)] = type(self._cache[(n_k, c_k)])(v)
             else:
                 self._cache[(n_k, c_k)] = v

--- a/pytorch_pfn_extras/config.py
+++ b/pytorch_pfn_extras/config.py
@@ -141,7 +141,10 @@ class Config(object):
     def update_via_args(self, args: Sequence[Tuple[str, Any]]) -> None:
         for k, v in args:
             n_k, c_k = _parse_key(k, ())[:2]
-            self._cache[(n_k, c_k)] = v
+            if (n_k, c_k) in self._cache:
+                self._cache[(n_k, c_k)] = type(self._cache[(n_k, c_k)])(v)
+            else:
+                self._cache[(n_k, c_k)] = v
 
 
 def _parse_key(

--- a/tests/pytorch_pfn_extras_tests/test_config.py
+++ b/tests/pytorch_pfn_extras_tests/test_config.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 import unittest
+import pytest
 
 from pytorch_pfn_extras.config import Config
 from pytorch_pfn_extras.config import customize_type
@@ -283,3 +284,24 @@ class TestConfig(unittest.TestCase):
         assert config['/foo/ls/0'] == 0
         config.update_via_args([('/foo/ls/0', '16')])
         assert config['/foo/ls/0'] == 16
+
+    def test_config_with_args_update_type_conversion_bool(self):
+        config = Config({
+            'foo': {
+                'ls': [True]
+            }
+        }, self.types)
+
+        assert config['/foo/ls/0']
+        config.update_via_args([('/foo/ls/0', False)])
+        assert not config['/foo/ls/0']
+        config.update_via_args([('/foo/ls/0', "False")])
+        assert not config['/foo/ls/0']
+        config.update_via_args([('/foo/ls/0', "true")])
+        assert config['/foo/ls/0']
+        config.update_via_args([('/foo/ls/0', "TRUE")])
+        assert config['/foo/ls/0']
+        config.update_via_args([('/foo/ls/0', "false")])
+        assert not config['/foo/ls/0']
+        with pytest.raises(ValueError):
+            config.update_via_args([('/foo/ls/0', "alse")])

--- a/tests/pytorch_pfn_extras_tests/test_config.py
+++ b/tests/pytorch_pfn_extras_tests/test_config.py
@@ -272,3 +272,14 @@ class TestConfig(unittest.TestCase):
         assert config['/foo/ls/0'] == 'first'
         config.update_via_args([('/foo/ls/0', 'changed')])
         assert config['/foo/ls/0'] == 'changed'
+
+    def test_config_with_args_update_type_conversion(self):
+        config = Config({
+            'foo': {
+                'ls': [0]
+            }
+        }, self.types)
+
+        assert config['/foo/ls/0'] == 0
+        config.update_via_args([('/foo/ls/0', '16')])
+        assert config['/foo/ls/0'] == 16


### PR DESCRIPTION
If updating the config items via arg.params, the user will need to convert the items to the datatypes increasing the burden.
This casts the new items to the type of the existing items in the config if any.