### PR TITLE
PoC implementation for distributed evaluators

### DIFF
--- a/pytorch_pfn_extras/distributed/__init__.py
+++ b/pytorch_pfn_extras/distributed/__init__.py
@@ -1,2 +1,3 @@
 from pytorch_pfn_extras.distributed._dataset_util import create_distributed_subset_indices  # NOQA
+from pytorch_pfn_extras.distributed._distributed_validation_sampler import DistributedValidationSampler  # NOQA
 from pytorch_pfn_extras.distributed._initialize import initialize_ompi_environment  # NOQA

--- a/pytorch_pfn_extras/distributed/_distributed_validation_sampler.py
+++ b/pytorch_pfn_extras/distributed/_distributed_validation_sampler.py
@@ -1,0 +1,59 @@
+from typing import TypeVar, Optional, Iterator, Sized
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+
+T_co = TypeVar('T_co', covariant=True)
+
+
+class DistributedValidationSampler(torch.utils.data.Sampler):
+    """Distributed sampler without duplication
+
+    This sampler splits the input dataset to each worker process in distributed setup
+    without allowing repetition.
+    It is for evaluation purpose such as :class:`~DistributedEvaluator`.
+    This does not guarantee each worker to get the same number of samples,
+    so for training do not use this sampler (use PyTorch DistributedSampler instead).
+    """
+
+    def __init__(self,
+                 dataset: Sized,
+                 num_replicas: Optional[int] = None,
+                 rank: Optional[int] = None, shuffle: bool = True,
+                 seed: int = 0) -> None:
+        if num_replicas is None:
+            if not dist.is_available():  # type: ignore[no-untyped-call]
+                raise RuntimeError("Requires distributed package to be available")
+            num_replicas = dist.get_world_size()  # type: ignore[no-untyped-call]
+        if rank is None:
+            if not dist.is_available():  # type: ignore[no-untyped-call]
+                raise RuntimeError("Requires distributed package to be available")
+            rank = dist.get_rank()  # type: ignore[no-untyped-call]
+        if rank >= num_replicas or rank < 0:
+            raise ValueError(
+                "Invalid rank {}, rank should be in the interval"
+                " [0, {}]".format(rank, num_replicas - 1))
+        self.dataset = dataset
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.shuffle = shuffle
+        self.seed = seed
+
+        self.dataset_len = len(dataset)
+        self.num_samples = len(np.array_split(range(self.dataset_len), num_replicas)[rank])
+
+    def __iter__(self) -> Iterator[T_co]:
+        if self.shuffle:
+            # deterministically shuffle based on epoch and seed
+            g = torch.Generator()
+            g.manual_seed(self.seed)
+            indices = torch.randperm(self.dataset_len, generator=g).tolist()
+        else:
+            indices = list(range(self.dataset_len))
+
+        return iter(np.array_split(indices, self.num_replicas)[self.rank])
+
+    def __len__(self) -> int:
+        return self.num_samples

--- a/pytorch_pfn_extras/reporting.py
+++ b/pytorch_pfn_extras/reporting.py
@@ -367,6 +367,14 @@ class Summary:
         self._x2 = float(_nograd(to_load['_x2']))
         self._n = int(_nograd(to_load['_n']))
 
+    def __add__(self, other: "Summary") -> "Summary":
+        s = Summary()
+        s._x = self._x + other._x
+        s._x2 = self._x2 + other._x2
+        s._n = self._n + other._n
+        s._deferred = self._deferred + other._deferred
+        return s
+
 
 class DictSummary:
 
@@ -443,3 +451,16 @@ class DictSummary:
         self._summaries.clear()
         for name, summ_state in to_load.items():
             self._summaries[name].load_state_dict(summ_state)
+
+    def __add__(self, other: "DictSummary") -> "DictSummary":
+        ours, other = self._summaries, other._summaries
+        ds = DictSummary()
+        for k in sorted(list(set([*ours.keys(), *other.keys()]))):
+            if k not in ours:
+                s: Summary = other[k]
+            elif k not in other:
+                s: Summary = ours[k]
+            else:
+                s: Summary = ours[k] + other[k]
+            ds._summaries[k] = s
+        return ds

--- a/pytorch_pfn_extras/reporting.py
+++ b/pytorch_pfn_extras/reporting.py
@@ -453,14 +453,13 @@ class DictSummary:
             self._summaries[name].load_state_dict(summ_state)
 
     def __add__(self, other: "DictSummary") -> "DictSummary":
-        ours, other = self._summaries, other._summaries
+        s1, s2 = self._summaries, other._summaries
         ds = DictSummary()
-        for k in sorted(list(set([*ours.keys(), *other.keys()]))):
-            if k not in ours:
-                s: Summary = other[k]
-            elif k not in other:
-                s: Summary = ours[k]
+        for k in sorted(list(set([*s1.keys(), *s2.keys()]))):
+            if k not in s1:
+                ds._summaries[k] = s2[k]
+            elif k not in s2:
+                ds._summaries[k] = s1[k]
             else:
-                s: Summary = ours[k] + other[k]
-            ds._summaries[k] = s
+                ds._summaries[k] = s1[k] + s2[k]
         return ds

--- a/pytorch_pfn_extras/training/__init__.py
+++ b/pytorch_pfn_extras/training/__init__.py
@@ -11,3 +11,4 @@ from pytorch_pfn_extras.training.manager import IgniteExtensionsManager  # NOQA
 from pytorch_pfn_extras.training.metrics import AccuracyMetric  # NOQA
 from pytorch_pfn_extras.training._trainer import Trainer  # NOQA
 from pytorch_pfn_extras.training._evaluator import Evaluator  # NOQA
+from pytorch_pfn_extras.training._evaluator import DistributedEvaluator  # NOQA

--- a/pytorch_pfn_extras/training/extensions/__init__.py
+++ b/pytorch_pfn_extras/training/extensions/__init__.py
@@ -4,7 +4,7 @@ from pytorch_pfn_extras.training.extensions._snapshot import snapshot_object  # 
 from pytorch_pfn_extras.training.extensions.best_value import BestValue  # NOQA
 from pytorch_pfn_extras.training.extensions.best_value import MaxValue  # NOQA
 from pytorch_pfn_extras.training.extensions.best_value import MinValue  # NOQA
-from pytorch_pfn_extras.training.extensions.evaluator import Evaluator, IgniteEvaluator  # NOQA
+from pytorch_pfn_extras.training.extensions.evaluator import Evaluator, DistributedEvaluator, IgniteEvaluator  # NOQA
 from pytorch_pfn_extras.training.extensions.fail_on_non_number import FailOnNonNumber  # NOQA
 from pytorch_pfn_extras.training.extensions.log_report import LogReport  # NOQA
 from pytorch_pfn_extras.training.extensions.lr_scheduler import LRScheduler  # NOQA

--- a/pytorch_pfn_extras/training/extensions/evaluator.py
+++ b/pytorch_pfn_extras/training/extensions/evaluator.py
@@ -298,7 +298,7 @@ class DistributedEvaluator(Evaluator):
             eval_func: Optional[Callable[..., Any]] = None,
             **kwargs: Any,
     ) -> None:
-        if not torch.distributed.is_initialized():
+        if not torch.distributed.is_initialized():  # type: ignore[no-untyped-call]
             msg = "PyTorch distributed module is not initialized. " \
                   "Initialize process group or use non-distributed Evaluator."
             raise RuntimeError(msg)
@@ -309,8 +309,9 @@ class DistributedEvaluator(Evaluator):
         super().__init__(iterator, target, eval_hook, eval_func, **kwargs)
 
     def _gather_summaries(self, summary: reporting.DictSummary) -> reporting.DictSummary:
-        summaries = [None] * torch.distributed.get_world_size()
-        torch.distributed.all_gather_object(summaries, summary)
+        world_size = torch.distributed.get_world_size()  # type: ignore[no-untyped-call]
+        summaries = [reporting.DictSummary() for _ in range(world_size)]
+        torch.distributed.all_gather_object(summaries, summary)  # type: ignore[no-untyped-call]
         return sum(summaries, reporting.DictSummary())
 
 

--- a/pytorch_pfn_extras/training/extensions/evaluator.py
+++ b/pytorch_pfn_extras/training/extensions/evaluator.py
@@ -7,6 +7,7 @@ from typing import (
 
 import numpy
 import torch
+import torch.distributed
 
 from pytorch_pfn_extras import reporting
 from pytorch_pfn_extras.training import extension
@@ -189,6 +190,9 @@ class Evaluator(extension.Extension):
         reporting.report(result)
         return result
 
+    def _gather_summaries(self, summary: reporting.DictSummary) -> reporting.DictSummary:
+        return summary
+
     def evaluate(self) -> Dict[str, _Scalar]:
         """Evaluates the model and returns a result dictionary.
 
@@ -240,6 +244,8 @@ class Evaluator(extension.Extension):
         if self._progress_bar:
             pbar.close()
 
+        summary = self._gather_summaries(summary)
+
         return summary.compute_mean()
 
     def finalize(self) -> None:
@@ -251,6 +257,61 @@ class Evaluator(extension.Extension):
 
         """
         pass
+
+
+class DistributedEvaluator(Evaluator):
+
+    """__init__(self, iterator, target, eval_func=None, *, progress_bar=False)
+
+    An extension to evaluate models on a validation set in a distributed training setup.
+
+    In case torch.distributed is used to parallelize training iterations,
+    it is efficient to also run evaluation in parallel by splitting the validation set
+    to each worker process and conduct evaluation separately followed by aggregation
+    of results of each worker, which can be achieved by :class:~`DistributedEvaluator`.
+
+    This extension basically behaves similarly to :class:`~Evaluator`,
+    but adds an aggregation step in :func:`Evaluator.evaluate`.
+    A summary of evaluation (:class:`~DictSummary`) in each worker process
+    is collected in "all-gather" manner and then accumulated.
+    Therefore all the worker processes must attend the evaluation,
+    i.e., make sure all the processes have a :class:`~Evaluator` extension object
+    configured in the :class:`~ExtensionManager` with the same trigger.
+    All the worker process will get identical evaluation result returned by :func:`Evaluator.evaluate`
+    and reported to an observation.
+
+    It is necessary to pass a DataLoader with an appropripate sampler which properly
+    splits the validation dataset to each MPI worker process.
+    PyTorch DistributedSampler implements this, but it allows sampler repetition
+    in order to make the number of samples assigned to each process identical.
+    For evaluation purpose it distorts the evaluation result,
+    hence it is recommended to use :class:`~DistributedValidationSampler` instead.
+
+    """
+
+    def __init__(
+            self,
+            iterator: Union[torch.utils.data.DataLoader[Any],
+                            Dict[str, torch.utils.data.DataLoader[Any]]],
+            target: Union[torch.nn.Module, Dict[str, torch.nn.Module]],
+            eval_hook: Optional[Callable[['Evaluator'], None]] = None,
+            eval_func: Optional[Callable[..., Any]] = None,
+            **kwargs: Any,
+    ) -> None:
+        if not torch.distributed.is_initialized():
+            msg = "PyTorch distributed module is not initialized. " \
+                  "Initialize process group or use non-distributed Evaluator."
+            raise RuntimeError(msg)
+
+        if 'progress_bar' in kwargs:
+            kwargs['progress_bar'] &= (torch.distributed.get_rank() == 0)
+
+        super().__init__(iterator, target, eval_hook, eval_func, **kwargs)
+
+    def _gather_summaries(self, summary: reporting.DictSummary) -> reporting.DictSummary:
+        summaries = [None] * torch.distributed.get_world_size()
+        torch.distributed.all_gather_object(summaries, summary)
+        return sum(summaries, reporting.DictSummary())
 
 
 @contextlib.contextmanager

--- a/pytorch_pfn_extras/training/extensions/evaluator.py
+++ b/pytorch_pfn_extras/training/extensions/evaluator.py
@@ -311,7 +311,8 @@ class DistributedEvaluator(Evaluator):
             raise RuntimeError(msg)
 
         if 'progress_bar' in kwargs:
-            kwargs['progress_bar'] &= (torch.distributed.get_rank() == 0)
+            rank = torch.distributed.get_rank()  # type: ignore[no-untyped-call]
+            kwargs['progress_bar'] &= (rank == 0)
 
         super().__init__(iterator, target, eval_hook, eval_func, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     license='MIT License',
     install_requires=['numpy', 'packaging', 'torch', 'typing-extensions>=3.10'],
     extras_require={
-        'test': ['pytest', 'pytest-mock', 'onnxruntime', 'torchvision'],
+        'test': ['pytest', 'onnxruntime', 'torchvision'],
         'onnx': ['onnx'],
     },
     python_requires='>=3.6.0',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     license='MIT License',
     install_requires=['numpy', 'packaging', 'torch', 'typing-extensions>=3.10'],
     extras_require={
-        'test': ['pytest', 'onnxruntime', 'torchvision'],
+        'test': ['pytest', 'pytest-mock', 'onnxruntime', 'torchvision'],
         'onnx': ['onnx'],
     },
     python_requires='>=3.6.0',

--- a/tests/pytorch_pfn_extras_tests/distributed_tests/test_distributed_validation_sampler.py
+++ b/tests/pytorch_pfn_extras_tests/distributed_tests/test_distributed_validation_sampler.py
@@ -1,0 +1,83 @@
+import torch.distributed as dist
+
+import pytest
+
+from pytorch_pfn_extras.distributed import DistributedValidationSampler
+
+_world_size = 4
+_dataset_len = 21
+
+
+@pytest.fixture
+def base_dataset():
+    return list(range(_dataset_len))
+
+
+def test_default(mocker, base_dataset):
+    mocker.patch.object(dist, 'get_world_size', return_value=_world_size)
+    mocker.patch.object(dist, 'is_available', return_value=True)
+
+    expected_lengths = [6, 5, 5, 5]
+    sample_idxs = []
+    for rank in range(_world_size):
+        mocker.patch.object(dist, 'get_rank', return_value=rank)
+        sampler = DistributedValidationSampler(base_dataset)
+        assert len(sampler) == expected_lengths[rank]
+        sample_idxs += list(sampler)
+
+    # Check no duplication among workers
+    assert len(sample_idxs) == len(set(sample_idxs)) == _dataset_len
+
+    # ordered randomly by default
+    assert sample_idxs != sorted(sample_idxs)
+
+
+def test_no_shuffle(mocker, base_dataset):
+    mocker.patch.object(dist, 'get_world_size', return_value=_world_size)
+    mocker.patch.object(dist, 'is_available', return_value=True)
+
+    expected_samples = [
+        [0, 1, 2, 3, 4, 5],
+        [6, 7, 8, 9, 10],
+        [11, 12, 13, 14, 15],
+        [16, 17, 18, 19, 20],
+    ]
+    for rank in range(_world_size):
+        mocker.patch.object(dist, 'get_rank', return_value=rank)
+        sampler = DistributedValidationSampler(base_dataset, shuffle=False)
+        assert list(sampler) == expected_samples[rank]
+
+
+def test_manual_num_replicas_and_ranks(mocker, base_dataset):
+    # When manually specifying num_replicas and rank,
+    # it doesn't rely on these torch.distributed functions.
+    mocker.patch.object(dist, 'get_world_size', side_effect=AssertionError())
+    mocker.patch.object(dist, 'is_available', return_value=AssertionError())
+    mocker.patch.object(dist, 'get_rank', return_value=AssertionError())
+
+    expected_lengths = [6, 5, 5, 5]
+    for rank in range(_world_size):
+        sampler = DistributedValidationSampler(base_dataset, num_replicas=_world_size, rank=rank)
+        assert len(sampler) == expected_lengths[rank]
+
+
+def test_seed(base_dataset):
+    sampler1 = DistributedValidationSampler(base_dataset, num_replicas=_world_size, rank=0, seed=1)
+    sampler2 = DistributedValidationSampler(base_dataset, num_replicas=_world_size, rank=0, seed=2)
+    assert list(sampler1) != list(sampler2)
+
+
+def test_no_distributed_available(base_dataset):
+    with pytest.raises(RuntimeError):
+        DistributedValidationSampler(base_dataset, num_replicas=_world_size)
+    with pytest.raises(RuntimeError):
+        DistributedValidationSampler(base_dataset, rank=0)
+
+
+def test_invalid_rank(mocker, base_dataset):
+    mocker.patch.object(dist, 'get_world_size', return_value=_world_size)
+
+    with pytest.raises(ValueError):
+        DistributedValidationSampler(base_dataset, rank=-1)
+    with pytest.raises(ValueError):
+        DistributedValidationSampler(base_dataset, rank=_world_size)

--- a/tests/pytorch_pfn_extras_tests/distributed_tests/test_distributed_validation_sampler.py
+++ b/tests/pytorch_pfn_extras_tests/distributed_tests/test_distributed_validation_sampler.py
@@ -1,6 +1,7 @@
 import torch.distributed as dist
 
 import pytest
+from unittest import mock
 
 from pytorch_pfn_extras.distributed import DistributedValidationSampler
 
@@ -13,17 +14,16 @@ def base_dataset():
     return list(range(_dataset_len))
 
 
-def test_default(mocker, base_dataset):
-    mocker.patch.object(dist, 'get_world_size', return_value=_world_size)
-    mocker.patch.object(dist, 'is_available', return_value=True)
-
+def test_default(base_dataset):
     expected_lengths = [6, 5, 5, 5]
     sample_idxs = []
-    for rank in range(_world_size):
-        mocker.patch.object(dist, 'get_rank', return_value=rank)
-        sampler = DistributedValidationSampler(base_dataset)
-        assert len(sampler) == expected_lengths[rank]
-        sample_idxs += list(sampler)
+    with mock.patch.object(dist, 'get_world_size', return_value=_world_size), \
+         mock.patch.object(dist, 'is_available', return_value=True):
+        for rank in range(_world_size):
+            with mock.patch.object(dist, 'get_rank', return_value=rank):
+                sampler = DistributedValidationSampler(base_dataset)
+                assert len(sampler) == expected_lengths[rank]
+                sample_idxs += list(sampler)
 
     # Check no duplication among workers
     assert len(sample_idxs) == len(set(sample_idxs)) == _dataset_len
@@ -32,33 +32,31 @@ def test_default(mocker, base_dataset):
     assert sample_idxs != sorted(sample_idxs)
 
 
-def test_no_shuffle(mocker, base_dataset):
-    mocker.patch.object(dist, 'get_world_size', return_value=_world_size)
-    mocker.patch.object(dist, 'is_available', return_value=True)
-
+def test_no_shuffle(base_dataset):
     expected_samples = [
         [0, 1, 2, 3, 4, 5],
         [6, 7, 8, 9, 10],
         [11, 12, 13, 14, 15],
         [16, 17, 18, 19, 20],
     ]
-    for rank in range(_world_size):
-        mocker.patch.object(dist, 'get_rank', return_value=rank)
-        sampler = DistributedValidationSampler(base_dataset, shuffle=False)
-        assert list(sampler) == expected_samples[rank]
+    with mock.patch.object(dist, 'get_world_size', return_value=_world_size), \
+         mock.patch.object(dist, 'is_available', return_value=True):
+        for rank in range(_world_size):
+            with mock.patch.object(dist, 'get_rank', return_value=rank):
+                sampler = DistributedValidationSampler(base_dataset, shuffle=False)
+                assert list(sampler) == expected_samples[rank]
 
 
-def test_manual_num_replicas_and_ranks(mocker, base_dataset):
+def test_manual_num_replicas_and_ranks(base_dataset):
     # When manually specifying num_replicas and rank,
     # it doesn't rely on these torch.distributed functions.
-    mocker.patch.object(dist, 'get_world_size', side_effect=AssertionError())
-    mocker.patch.object(dist, 'is_available', return_value=AssertionError())
-    mocker.patch.object(dist, 'get_rank', return_value=AssertionError())
-
     expected_lengths = [6, 5, 5, 5]
-    for rank in range(_world_size):
-        sampler = DistributedValidationSampler(base_dataset, num_replicas=_world_size, rank=rank)
-        assert len(sampler) == expected_lengths[rank]
+    with mock.patch.object(dist, 'get_world_size', side_effect=AssertionError()), \
+         mock.patch.object(dist, 'is_available', side_effect=AssertionError()), \
+         mock.patch.object(dist, 'get_rank', side_effect=AssertionError()):
+        for rank in range(_world_size):
+            sampler = DistributedValidationSampler(base_dataset, num_replicas=_world_size, rank=rank)
+            assert len(sampler) == expected_lengths[rank]
 
 
 def test_seed(base_dataset):
@@ -74,10 +72,9 @@ def test_no_distributed_available(base_dataset):
         DistributedValidationSampler(base_dataset, rank=0)
 
 
-def test_invalid_rank(mocker, base_dataset):
-    mocker.patch.object(dist, 'get_world_size', return_value=_world_size)
-
-    with pytest.raises(ValueError):
-        DistributedValidationSampler(base_dataset, rank=-1)
-    with pytest.raises(ValueError):
-        DistributedValidationSampler(base_dataset, rank=_world_size)
+def test_invalid_rank(base_dataset):
+    with mock.patch.object(dist, 'get_world_size', return_value=_world_size):
+        with pytest.raises(ValueError):
+            DistributedValidationSampler(base_dataset, rank=-1)
+        with pytest.raises(ValueError):
+            DistributedValidationSampler(base_dataset, rank=_world_size)

--- a/tests/pytorch_pfn_extras_tests/test_reporter.py
+++ b/tests/pytorch_pfn_extras_tests/test_reporter.py
@@ -242,6 +242,26 @@ def test_summary_deferred_add():
     assert summary.compute_mean() == 1.0
 
 
+def test_summary_add_operator():
+    s1 = ppe.reporting.Summary()
+    s1.add(1.)
+    s1.add(2.)
+    s1.add(3.)
+
+    s2 = ppe.reporting.Summary()
+    s2.add(4.)
+    s2.add(5.)
+    s2.add(6.)
+    s2.add(7.)
+
+    s = s1 + s2
+    assert s.state_dict() == {
+        '_x': 28.0,
+        '_x2': 140.0,
+        '_n': 7,
+    }
+
+
 def _nograd(v):
     if isinstance(v, torch.Tensor):
         return v.detach()
@@ -492,4 +512,23 @@ def test_dict_summary_deferred_add():
     _check_dict_summary(summary, {
         "x": (1.0, -1.0),
         "y": (2.0,),
+    })
+
+
+def test_dict_summary_add_operator():
+    s1 = ppe.reporting.DictSummary()
+    s1.add({'a': 1., 'b': 0.1, 'c': 0.01})
+    s1.add({'a': 2., 'b': 0.2, 'c': 0.02})
+
+    s2 = ppe.reporting.DictSummary()
+    s2.add({'a': 3., 'b': 0.3, 'f': 0.03})
+    s2.add({'a': 4., 'b': 0.4, 'f': 0.04})
+    s2.add({'a': 5., 'b': 0.5, 'f': 0.05})
+
+    s = s1 + s2
+    _check_dict_summary(s, {
+        'a': [1, 2, 3, 4, 5],
+        'b': [0.1, 0.2, 0.3, 0.4, 0.5],
+        'c': [0.01, 0.02],
+        'f': [0.03, 0.04, 0.05],
     })


### PR DESCRIPTION
Current evaluator mechanism (ppe.training.extensions.Evaluator) is not distributed-aware. Those who use distributed training currently run evaluation for the entire dataset on a single (typically rank=0) worker and let other workers just wait, or  maybe using only part of the evaluation dataset for evaluation during training.
The problem is two-fold.
- ppe Evaluator and Summary/DictSummary don't have mechanisms to collect evaluation results from other MPI workers.
- DistributedSampler is not suitable for evaluation.

This PoC provides several new interfaces for distributed evaluation on top of the ExtensionManager mechanism, by basically extends the Evaluator extension, which also includes:
* A mechanism to collect evaluation results from all workers (`__add__` operator for Summary and DictSummary).
* A variant of DistributedSampler with no sample duplication, which is dedicated for evaluation purpose
    * It guarantees each sample in a dataset is evaluated exactly once.
    * Batch-size won't be guaranteed to be fixed, number of batches for each worker either. So it should never be used for models that includes MPI communication.

Currently this doesn't include any implementations for `ppe.trainer`.
This is mainly because I first want to confirm if this approach is good to go or not. Also I have no idea how `create_evaluator` should look like to support distributed evaluation.