### PR TITLE
Support exporting testcases with scripted modules

### DIFF
--- a/pytorch_pfn_extras/onnx/_as_output.py
+++ b/pytorch_pfn_extras/onnx/_as_output.py
@@ -3,6 +3,7 @@ from typing import Any, Generator, List, NamedTuple, Tuple, Union
 import torch
 import threading
 from contextlib import contextmanager
+import warnings
 
 _outputs = threading.local()
 
@@ -99,6 +100,9 @@ def trace(
 
 def as_output(name: str, value: torch.Tensor) -> torch.Tensor:
     if torch.jit.is_scripting():
+        warnings.warn(
+            '`as_output` seen in TorchScript compilation. The value is no '
+            'longer an output in the exported onnx.')
         return value
     if hasattr(_outputs, "outputs") and _outputs.outputs is not None:
         _outputs.outputs.add(name, value)

--- a/pytorch_pfn_extras/onnx/_as_output.py
+++ b/pytorch_pfn_extras/onnx/_as_output.py
@@ -99,7 +99,7 @@ def trace(
 
 
 def as_output(name: str, value: torch.Tensor) -> torch.Tensor:
-    if torch.jit.is_scripting():
+    if torch.jit.is_scripting():  # type: ignore[no-untyped-call]
         warnings.warn(
             '`as_output` seen in TorchScript compilation. The value is no '
             'longer an output in the exported onnx.')

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -233,7 +233,7 @@ def export(
 
 
 def export_testcase(
-        model: torch.nn.Module,
+        model: Union[torch.nn.Module, torch.jit.ScriptModule],
         args: Any,
         out_dir: str,
         *,
@@ -288,6 +288,8 @@ def export_testcase(
     onnx_graph, outs = _export(
         model, args, strip_large_tensor_data, large_tensor_threshold,
         input_names=input_names, **kwargs)
+    if isinstance(model, torch.jit.ScriptModule):
+        outs = model(*args)
     if isinstance(outs, torch.Tensor):
         outs = outs,
     elif outs is None:

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -314,29 +314,14 @@ def export_testcase(
         with open(output_path, 'wb') as fp:
             fp.write(onnx_graph.SerializeToString())
 
-    def write_to_pb(
-            f: str, tensor: Union[torch.Tensor, Sequence[torch.Tensor]],
-            name: Optional[str] = None
-    ) -> None:
-        if isinstance(tensor, torch.Tensor):
-            array = tensor.detach().cpu().numpy()
-            with open(f, 'wb') as fp:
-                t = onnx.numpy_helper.from_array(array, name)
-                if (strip_large_tensor_data
-                        and is_large_tensor(t, large_tensor_threshold)):
-                    _strip_raw_data(t)
-                fp.write(t.SerializeToString())
-        elif isinstance(tensor, Sequence):
-            array = [t.detach().cpu().numpy() for t in tensor]
-            with open(f, 'wb') as fp:
-                s = onnx.numpy_helper.from_list(array, name)
-                if strip_large_tensor_data:
-                    for t in s.tensor_values:
-                        if is_large_tensor(t, large_tensor_threshold):
-                            _strip_raw_data(t)
-                fp.write(s.SerializeToString())
-        else:
-            assert False
+    def write_to_pb(f: str, tensor: torch.Tensor, name: Optional[str] = None) -> None:
+        array = tensor.detach().cpu().numpy()
+        with open(f, 'wb') as fp:
+            t = onnx.numpy_helper.from_array(array, name)
+            if (strip_large_tensor_data
+                    and is_large_tensor(t, large_tensor_threshold)):
+                _strip_raw_data(t)
+            fp.write(t.SerializeToString())
 
     if export_torch_script:
         pt_script_path = os.path.join(out_dir, 'model_script.pt')

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -332,7 +332,7 @@ def export_testcase(
                 s = onnx.numpy_helper.from_list(array, name)
                 if strip_large_tensor_data:
                     for t in s.tensor_values:
-                        if (is_large_tensor(t, large_tensor_threshold)):
+                        if is_large_tensor(t, large_tensor_threshold):
                             _strip_raw_data(t)
                 fp.write(s.SerializeToString())
         else:

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -289,6 +289,7 @@ def export_testcase(
         model, args, strip_large_tensor_data, large_tensor_threshold,
         input_names=input_names, **kwargs)
     if isinstance(model, torch.jit.ScriptModule):
+        assert outs is None
         outs = model(*args)
     if isinstance(outs, torch.Tensor):
         outs = outs,

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py
@@ -95,3 +95,34 @@ def test_no_as_output():
     assert 'MatMul_2' in named_nodes
 
     assert len([v.name for v in actual_onnx.graph.output]) == 1
+
+
+def test_as_output_in_scripting():
+
+    class Net(nn.Module):
+
+        def __init__(self):
+            super(Net, self).__init__()
+            self.conv = nn.Conv2d(1, 6, 3)
+            self.linear = nn.Linear(30, 20, bias=False)
+
+        def forward(self, x, b):
+            h = self.conv(x)
+            if b:  # IF statement to check scripted (not traced) IR
+                h = -h
+            h = as_output("h", h)
+            h = self.linear(h)
+            return h
+
+    model = torch.jit.script(Net())
+    x = torch.ones((1, 1, 32, 32))
+    b = torch.tensor(True)
+    output_dir = _helper(model, (x, b), 'as_output', use_pfto=False)
+
+    actual_onnx = onnx.load(os.path.join(output_dir, 'model.onnx'))
+    named_nodes = {n.name: n for n in actual_onnx.graph.node}
+    assert 'Conv_0' in named_nodes
+    assert 'If_2' in named_nodes
+    assert 'MatMul_6' in named_nodes
+
+    assert len([v.name for v in actual_onnx.graph.output]) == 1

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py
@@ -97,6 +97,9 @@ def test_no_as_output():
     assert len([v.name for v in actual_onnx.graph.output]) == 1
 
 
+@pytest.mark.skipif(
+    not pytorch_pfn_extras.requires("1.10.0"),
+    reason='skip for PyTorch 1.9 or earlier')
 def test_as_output_in_scripting():
 
     class Net(nn.Module):

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py
@@ -117,7 +117,8 @@ def test_as_output_in_scripting():
     model = torch.jit.script(Net())
     x = torch.ones((1, 1, 32, 32))
     b = torch.tensor(True)
-    output_dir = _helper(model, (x, b), 'as_output', use_pfto=False)
+    with pytest.warns(UserWarning):
+        output_dir = _helper(model, (x, b), 'as_output', use_pfto=False)
 
     actual_onnx = onnx.load(os.path.join(output_dir, 'model.onnx'))
     named_nodes = {n.name: n for n in actual_onnx.graph.node}

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
@@ -456,6 +456,9 @@ def test_export_pt():
     assert os.path.exists(os.path.join(output_dir, 'model_trace.pt'))
 
 
+@pytest.mark.skipif(
+    not pytorch_pfn_extras.requires("1.10.0"),
+    reason='skip for PyTorch 1.9 or earlier')
 def test_export_scripted():
 
     class Net(nn.Module):

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
@@ -2,6 +2,7 @@ import io
 import os
 import json
 from pathlib import Path
+from typing import List
 
 import numpy as np
 import onnx
@@ -172,6 +173,16 @@ def _to_array(f, name=None):
     if name is not None:
         assert onnx_tensor.name == name
     return onnx.numpy_helper.to_array(onnx_tensor)
+
+
+def _to_list(f, name=None):
+    assert os.path.isfile(f)
+    onnx_seq = onnx.SequenceProto()
+    with open(f, 'rb') as fp:
+        onnx_seq.ParseFromString(fp.read())
+    if name is not None:
+        assert onnx_seq.name == name
+    return onnx.numpy_helper.to_list(onnx_seq)
 
 
 def test_backward():
@@ -459,7 +470,6 @@ def test_export_pt():
 def test_export_scripted():
 
     class Net(nn.Module):
-
         def __init__(self):
             super(Net, self).__init__()
             self.linear = nn.Linear(5, 10, bias=False)
@@ -483,3 +493,34 @@ def test_export_scripted():
     expected_out = torch.zeros((2, 10))  # check only shape size
     np.testing.assert_allclose(
         out.detach().cpu().numpy(), expected_out.detach().cpu().numpy())
+
+
+def test_export_scripted_list_of_tensors():
+
+    class Net(nn.Module):
+        def forward(self, xs: List[torch.Tensor]):
+            return xs[0]
+
+    model = torch.jit.script(Net())
+    xs = [torch.zeros((2, 5)), torch.zeros((2, 5))]
+
+    output_dir = _get_output_dir('export_scripted')
+    (out,) = export_testcase(
+        model, (xs,), output_dir, return_output=True, training=model.training,
+        do_constant_folding=False)
+
+    # Check model.onnx
+    assert os.path.isfile(os.path.join(output_dir, 'model.onnx'))
+
+    # Check returned output
+    expected_out = torch.zeros((2, 5))  # check only shape size
+    np.testing.assert_allclose(
+        out.detach().cpu().numpy(), expected_out.detach().cpu().numpy())
+
+    # Check input_0.pb
+    test_data_set_dir = os.path.join(output_dir, 'test_data_set_0')
+    expected_input_0_path = os.path.join(test_data_set_dir, 'input_0.pb')
+    xs0 = _to_list(expected_input_0_path, 'input_0')
+    assert len(xs0) == 2
+    assert xs[0].shape == xs0[0].shape
+    assert xs[1].shape == xs0[1].shape


### PR DESCRIPTION
Currently, `onnx.export_testcase` seems not to support exporting test cases with scripted (not traced) TorchScript modules, that is, instances of `torch.jit.ScriptedModule`.

I found its `as_output` feature prevented it from exporting scripted modules, and I've fixed it just to bypass `_ModuleWithAdditionalOutputs` as, I suppose, `as_output` feature essentially does not work with scripting at the same time.
