### PR TITLE
[PFTO] Save denotation with uppercase

### DIFF
--- a/pytorch_pfn_extras/onnx/pfto_exporter/export.py
+++ b/pytorch_pfn_extras/onnx/pfto_exporter/export.py
@@ -58,7 +58,7 @@ def _type_to_proto(t: torch._C.TensorType) -> onnx.TypeProto:
         return onnx.TypeProto()
 
     ret: onnx.TypeProto = onnx.TypeProto()
-    ret.denotation = repr(t)
+    ret.denotation = repr(t).upper()
 
     if t.kind() == "ListType":
         ret.sequence_type.elem_type.CopyFrom(_type_to_proto(cast(torch._C.TensorType, t.getElementType())))


### PR DESCRIPTION
ONNX standard denotations are uppercase.
https://github.com/onnx/onnx/blob/02d8f9626f1352e3837d35f45f2f37270e4b85a1/docs/TypeDenotation.md#type-denotation-definition


Especially, when visualizing ONNX with netron, denotation string is case-sensitive.
https://github.com/lutzroeder/netron/blob/4fe5bfc790be57c6b107877b66d583d8192d7b8d/source/onnx.js#L1656