### PR TITLE
[PFTO] Set domain for custom onnx nodes

### DIFF
--- a/pytorch_pfn_extras/onnx/pfto_exporter/export.py
+++ b/pytorch_pfn_extras/onnx/pfto_exporter/export.py
@@ -850,6 +850,7 @@ class _Exporter(_ExporterOptions):
         model: onnx.ModelProto = onnx.helper.make_model(
             graph,
             opset_imports=[onnx.helper.make_opsetid("", self.opset_version)],
+            producer_name="pfto",
         )
         model = self.check_model(model)
 

--- a/pytorch_pfn_extras/onnx/pfto_exporter/export.py
+++ b/pytorch_pfn_extras/onnx/pfto_exporter/export.py
@@ -715,7 +715,10 @@ class _Exporter(_ExporterOptions):
 
             new_nd = onnx.NodeProto()
             new_nd.name = node_name(n)
-            new_nd.op_type = n.kind().split("::")[-1]
+            ns, op = n.kind().split("::")
+            new_nd.op_type = op
+            if ns not in ["onnx", "prim"]:
+                new_nd.domain = ns
             if n.kind() == "prim::If":
                 if n in self.node_doc_string:
                     new_nd.doc_string = f"""## Symbolic node


### PR DESCRIPTION
# Problem
With current master's PFTO exporter, exporting a node with `org.Chainer::RandInt` produces a onnx node without `domain` attribute.
In such case, onnx checker raises error because the exported node will be considered to have default ("onnx") domain and there is no RandInt operator in onnx domain.

We need to set appropriate domain for custom operators.