### PR TITLE
[PFTO] Show better error when exporting tuple outputs

### DIFF
--- a/pytorch_pfn_extras/onnx/pfto_exporter/export.py
+++ b/pytorch_pfn_extras/onnx/pfto_exporter/export.py
@@ -829,6 +829,8 @@ class _Exporter(_ExporterOptions):
             inout_names.append(k)
             onnx_outputs.append(onnx_value(v, k))
             if idx < len(self.outputs):
+                if isinstance(self.outputs[idx], tuple):
+                    raise RuntimeError('Models returning nested lists/tuples are not supported yet')
                 _apply_tensor_info_to_value_info(onnx_outputs[-1], self.outputs[idx])
                 apply_dynamic_axes_info(onnx_outputs[-1], k)
 


### PR DESCRIPTION
Currently, PFTO does not support exporting models with nested tuple or list

# Reproduce
```python3
import torch
import pytorch_pfn_extras.onnx as tou

class Model(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.rnn = torch.nn.LSTM(13, 17, 2)
        self.x = torch.nn.parameter.Parameter(torch.randn(3, 7, 13))

    def forward(self, *hidden):
        return self.rnn(self.x, tuple(hidden))

tou.export_testcase(Model(), (torch.randn(2, 7, 17), torch.randn(2, 7, 17)), "test", use_pfto=True)
```

## Current error
```
in _apply_tensor_info_to_value_info
    v.type.tensor_type.elem_type = torch_dtype_to_onnx_data_type[t.dtype]
AttributeError: 'tuple' object has no attribute 'dtype'
```

## Updated error
```
in generate_onnx
    raise RuntimeError('Models returning nested lists/tuples are not supported yet')
RuntimeError: Models returning nested lists/tuples are not supported yet
```