### PR TITLE
Add a `finalize` method to `Trainer` and `ExtensionsManager` and finalize extensions when error is raised during iteration

### DIFF
--- a/pytorch_pfn_extras/training/_trainer.py
+++ b/pytorch_pfn_extras/training/_trainer.py
@@ -324,7 +324,7 @@ class Trainer:
                             # so training can continue and extensions state is not
                             # finalized. On the other hand, the trainer is not
                             # reusable, so we finalize the extensions here.
-                            self.manager.close()
+                            self.manager.finalize()
                             raise
 
                     if prof is not None:

--- a/pytorch_pfn_extras/training/_trainer.py
+++ b/pytorch_pfn_extras/training/_trainer.py
@@ -332,6 +332,12 @@ class Trainer:
                 prof.on_trace_ready = None
         self.handler.train_cleanup(self)
 
+    def close(self) -> None:
+        if self._manager is not None:
+            self._manager.close()
+        else:
+            raise RuntimeError('Attempted to close a non-started trainer')
+
 
 # For backward compatibility
 _Trainer = Trainer

--- a/pytorch_pfn_extras/training/_trainer.py
+++ b/pytorch_pfn_extras/training/_trainer.py
@@ -301,22 +301,32 @@ class Trainer:
                         self._idxs.put(idx)
                         self._inputs.put(x)
                         self._times.put(begin)
-                        with record(
-                            "pytorch_pfn_extras.training.Trainer:run_iteration",
-                            use_cuda=torch.cuda.is_available(),
-                            enable=self._enable_profile
-                        ) as ntf1, \
-                                self.manager.run_iteration():
-                            self._observed.put(self.manager.observation)
+                        try:
                             with record(
-                                "pytorch_pfn_extras.training.Trainer:train_step",
+                                "pytorch_pfn_extras.training.Trainer:run_iteration",
                                 use_cuda=torch.cuda.is_available(),
                                 enable=self._enable_profile
-                            ) as ntf2:
-                                self._profile_records.put([ntf0, ntf1, ntf2])
-                                self.handler.train_step(
-                                    self, idx, x, complete_fn=self._complete_step)
-                                # Check if the callback was called
+                            ) as ntf1, \
+                                    self.manager.run_iteration():
+                                self._observed.put(self.manager.observation)
+                                with record(
+                                    "pytorch_pfn_extras.training.Trainer:train_step",
+                                    use_cuda=torch.cuda.is_available(),
+                                    enable=self._enable_profile
+                                ) as ntf2:
+                                    self._profile_records.put([ntf0, ntf1, ntf2])
+                                    self.handler.train_step(
+                                        self, idx, x, complete_fn=self._complete_step)
+                                    # Check if the callback was called
+                        except Exception:
+                            # The manager has errored and called the extensions
+                            # on_error. However the manager is reusable
+                            # so training can continue and extensions state is not
+                            # finalized. On the other hand, the trainer is not
+                            # reusable, so we finalize the extensions here.
+                            self.manager.close()
+                            raise
+
                     if prof is not None:
                         prof.step()  # type: ignore[no-untyped-call]
                     # In some cases, DataLoaders are continuos
@@ -331,12 +341,6 @@ class Trainer:
             if prof is not None:
                 prof.on_trace_ready = None
         self.handler.train_cleanup(self)
-
-    def close(self) -> None:
-        if self._manager is not None:
-            self._manager.close()
-        else:
-            raise RuntimeError('Attempted to close a non-started trainer')
 
 
 # For backward compatibility

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -583,7 +583,7 @@ class ExtensionsManager(_BaseExtensionsManager):
             to call `zero_grad` and `step`
         """
         if self._finalized:
-            raise RuntimeError('Attempted to run a closed manager')
+            raise RuntimeError('Attempted to run a finalized manager')
         if self._start_time is None:
             self._start_time = _get_time()
             self.start_extensions()

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -609,9 +609,9 @@ class ExtensionsManager(_BaseExtensionsManager):
                 raise
 
         if self._internal_stop_trigger(self):
-            self.close()
+            self.finalize()
 
-    def close(self) -> None:
+    def finalize(self) -> None:
         if not self._finalized:
             self._finalize_extensions()
             self.writer.finalize()

--- a/pytorch_pfn_extras/training/manager.py
+++ b/pytorch_pfn_extras/training/manager.py
@@ -158,6 +158,7 @@ class _BaseExtensionsManager:
             self.reporter.add_observer(name, model)
             self.reporter.add_observers(
                 name, model.named_modules())
+        self._finalized = False
         self.max_epochs = max_epochs
         self._start_iteration = 0
         # Defer!
@@ -581,6 +582,8 @@ class ExtensionsManager(_BaseExtensionsManager):
             step_optimizers (list or None): names of the optimizers
             to call `zero_grad` and `step`
         """
+        if self._finalized:
+            raise RuntimeError('Attempted to run a closed manager')
         if self._start_time is None:
             self._start_time = _get_time()
             self.start_extensions()
@@ -606,8 +609,13 @@ class ExtensionsManager(_BaseExtensionsManager):
                 raise
 
         if self._internal_stop_trigger(self):
+            self.close()
+
+    def close(self) -> None:
+        if not self._finalized:
             self._finalize_extensions()
             self.writer.finalize()
+            self._finalized = True
 
 
 if TYPE_CHECKING:

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_extension.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_extension.py
@@ -94,7 +94,7 @@ def test_on_error():
 
     optimizers = {'main': object()}
     manager = ppe.training.ExtensionsManager(
-        {}, optimizers, 1, iters_per_epoch=1)
+        {}, optimizers, 1, iters_per_epoch=2)
     ext = DummyExt()
     manager.extend(ext)
 

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
@@ -558,9 +558,9 @@ def test_finalize():
     with manager.run_iteration():
         pass
     assert ext.call_cnt == 1
-    assert ext.finalized == 1
+    assert ext.finalized
 
-    with pytest.raises(RuntimeError, match="closed manager"):
+    with pytest.raises(RuntimeError, match="finalized manager"):
         with manager.run_iteration():
             pass
 

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
@@ -537,7 +537,7 @@ def test_extensions_accessing_models_without_flag(priority):
                 pass
 
 
-def test_close():
+def test_finalize():
     class DummyExt(ppe.training.Extension):
         def __init__(self):
             self.call_cnt = 0

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
@@ -537,5 +537,33 @@ def test_extensions_accessing_models_without_flag(priority):
                 pass
 
 
+def test_close():
+    class DummyExt(ppe.training.Extension):
+        def __init__(self):
+            self.call_cnt = 0
+            self.finalized = False
+
+        def __call__(self, manager):
+            self.call_cnt += 1
+
+        def finalize(self, manager):
+            self.finalized = True
+
+    optimizers = {'main': object()}
+    manager = ppe.training.ExtensionsManager(
+        {}, optimizers, 1, iters_per_epoch=1)
+    ext = DummyExt()
+    manager.extend(ext)
+
+    with manager.run_iteration():
+        pass
+    assert ext.call_cnt == 1
+    assert ext.finalized == 1
+
+    with pytest.raises(RuntimeError, match="closed manager"):
+        with manager.run_iteration():
+            pass
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v', '-s'])


### PR DESCRIPTION
In some cases an exception occurs in user code (outside manager/trainer)
and we need to close the status of the extensions etc. in order to do a cleanup (I.e. non closing tensorboard may block the process).

```python
try:
   with manager.run_iteration():
       my_code()
   raise RuntimeError('foo')
finally:
   manager.close()
```
