### PR TITLE
Use ubuntu-22.04 as GitHub Actions runner image

### DIFF
--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         torch: ['1.9.*', '1.10.*', '1.11.*', '1.12.*']

--- a/.github/workflows/test-cpu.yml
+++ b/.github/workflows/test-cpu.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout


### PR DESCRIPTION
GitHub actions fully unsupports ubuntu-18.04 by 12/1/22.

https://github.com/actions/runner-images/issues/6002