### PR TITLE
Fix import failure when user account does not exist

### DIFF
--- a/pytorch_pfn_extras/training/extensions/slack.py
+++ b/pytorch_pfn_extras/training/extensions/slack.py
@@ -24,7 +24,17 @@ except ImportError:
     _slack_sdk_available = False
 
 
-_identity = f'{getpass.getuser()}@{socket.gethostname()} [PID {os.getpid()}]'
+def _failsafe(func: Callable[[], Any]) -> str:
+    # getpass.getuser() fails when user account does not exist.
+    try:
+        return str(func())
+    except Exception:
+        return 'UNKNOWN'
+
+
+_identity = (
+    f'{_failsafe(getpass.getuser)}@{_failsafe(socket.gethostname)} '
+    f'[PID {_failsafe(os.getpid)}]')
 
 
 def _default_msg(


### PR DESCRIPTION
```
>>> import getpass
>>> getpass.getuser()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.10/getpass.py", line 169, in getuser
    return pwd.getpwuid(os.getuid())[0]
KeyError: 'getpwuid(): uid not found: 12345'
```