### PR TITLE
[onnx] Disable logging in non-verbose

### DIFF
--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -157,7 +157,8 @@ def _export(
     bytesio = io.BytesIO()
     opset_ver = kwargs.get('opset_version', None)
     force_verbose = False
-    original_log = torch.onnx.log
+    if pytorch_pfn_extras.requires('1.12.0'):
+        original_log = torch.onnx.log
     if opset_ver is None:
         opset_ver = pytorch_pfn_extras.onnx._constants.onnx_default_opset
         kwargs['opset_version'] = opset_ver

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -158,7 +158,7 @@ def _export(
     opset_ver = kwargs.get('opset_version', None)
     force_verbose = False
     if pytorch_pfn_extras.requires('1.12.0'):
-        original_log = torch.onnx.log
+        original_log = torch.onnx.log  # type: ignore[attr-defined]
     if opset_ver is None:
         opset_ver = pytorch_pfn_extras.onnx._constants.onnx_default_opset
         kwargs['opset_version'] = opset_ver
@@ -173,9 +173,10 @@ def _export(
                 #  Following line won't work because verbose mode always
                 # enable logging so we are replacing python function instead:
                 # torch.onnx.disable_log()
-                def no_op(*args):
+                def no_op(*args: Any) -> None:
                     pass
-                torch.onnx.log = no_op
+
+                torch.onnx.log = no_op  # type: ignore[attr-defined]
         kwargs['verbose'] = True
     with init_annotate(model, opset_ver) as ann, \
             as_output.trace(model) as (model, outputs), \
@@ -199,7 +200,7 @@ def _export(
 
     if force_verbose:
         # torch.onnx.enable_log()
-        torch.onnx.log = original_log
+        torch.onnx.log = original_log  # type: ignore[attr-defined]
 
     return onnx_graph, outs
 

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -199,8 +199,9 @@ def _export(
         _strip_large_initializer_raw_data(onnx_graph, large_tensor_threshold)
 
     if force_verbose:
-        # torch.onnx.enable_log()
-        torch.onnx.log = original_log  # type: ignore[attr-defined]
+        if pytorch_pfn_extras.requires('1.12.0'):
+            # torch.onnx.enable_log()
+            torch.onnx.log = original_log  # type: ignore[attr-defined]
 
     return onnx_graph, outs
 

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -156,6 +156,8 @@ def _export(
     model.zero_grad()
     bytesio = io.BytesIO()
     opset_ver = kwargs.get('opset_version', None)
+    force_verbose = False
+    original_log = torch.onnx.log
     if opset_ver is None:
         opset_ver = pytorch_pfn_extras.onnx._constants.onnx_default_opset
         kwargs['opset_version'] = opset_ver
@@ -164,6 +166,15 @@ def _export(
         kwargs['strip_doc_string'] = False
     else:
         strip_doc_string = kwargs.pop('strip_doc_string', True)
+        if not kwargs.get('verbose', False):
+            force_verbose = True
+            if pytorch_pfn_extras.requires('1.12.0'):
+                #  Following line won't work because verbose mode always
+                # enable logging so we are replacing python function instead:
+                # torch.onnx.disable_log()
+                def no_op(*args):
+                    pass
+                torch.onnx.log = no_op
         kwargs['verbose'] = True
     with init_annotate(model, opset_ver) as ann, \
             as_output.trace(model) as (model, outputs), \
@@ -184,6 +195,10 @@ def _export(
 
     if strip_large_tensor_data:
         _strip_large_initializer_raw_data(onnx_graph, large_tensor_threshold)
+
+    if force_verbose:
+        # torch.onnx.enable_log()
+        torch.onnx.log = original_log
 
     return onnx_graph, outs
 


### PR DESCRIPTION
From torch 1.10 support we are passing `verbose=True` to enable doc_string but it makes stdout dirty so here is a workaround for it using torch.onnx logging feature introduced in torch 1.12.

- Ref https://github.com/pytorch/pytorch/commit/54a6942f8ddc5e9d5277938e163453e110432c5a
- Ref https://github.com/pfnet/pytorch-pfn-extras/pull/497
