### PR TITLE
Always create expected output for export_testcase

### DIFF
--- a/pytorch_pfn_extras/onnx/_grad.py
+++ b/pytorch_pfn_extras/onnx/_grad.py
@@ -85,7 +85,7 @@ def grad(
             @staticmethod
             def symbolic(g, output, grad_output, *inputs):  # type: ignore
                 return g.op(
-                    "Gradient",
+                    "ai.onnx.preview::Gradient",
                     *inputs,
                     xs_s=input_names,
                     zs_s=[],

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -155,7 +155,7 @@ def _export(
         strip_large_tensor_data: bool = False,
         large_tensor_threshold: int = LARGE_TENSOR_DATA_THRESHOLD,
         use_pfto: bool = False,
-        return_output: bool = False,
+        return_output: bool = True,
         **kwargs: Any,
 ) -> Tuple[onnx.ModelProto, Any]:
     model.zero_grad()


### PR DESCRIPTION
`_export_util` should always return outputs for `export_testcase`. Re-run the model to create outputs when ONNX checker fails.