### PR TITLE
[PFTO] Flatten nested outputs like torch.onnx

### DIFF
--- a/pytorch_pfn_extras/onnx/pfto_exporter/export.py
+++ b/pytorch_pfn_extras/onnx/pfto_exporter/export.py
@@ -95,10 +95,11 @@ def _remove_prefix(text: str, prefix: str) -> str:
     return text[text.startswith(prefix) and len(prefix) :]
 
 
-def _to_tuple_if_not_sequence(v: Any) -> Any:
-    if not isinstance(v, (list, tuple)):
-        v = (v,)
-    return v
+def _to_tuple_if_not_sequence(v: Any) -> Tuple:
+    if isinstance(v, (list, tuple)):
+        return tuple(v)
+    else:
+        return (v,)
 
 
 def onnx_node_doc_string(onnx_node: torch._C.Node, torch_node: torch._C.Node) -> str:
@@ -207,7 +208,8 @@ class _Exporter(_ExporterOptions):
 """
 
         # TODO(twata): Use `self.traced` instead or use traced result outputs
-        self.outputs = _to_tuple_if_not_sequence(self.original_model(*self.inputs))
+        self.original_outputs = self.original_model(*self.inputs)
+        self.flat_outputs = _to_tuple_if_not_sequence(torch._C._jit_flatten(self.original_outputs)[0])
         self.g: torch._C.Graph = self.traced.inlined_graph
         self.vars: Dict[str, torch.IValue] = {_remove_prefix(k, f"{_ppe_ignore_scope}."): v for k, v in self.traced.state_dict().items()}
         self.self_id: Optional[TorchValueID] = None
@@ -763,7 +765,7 @@ class _Exporter(_ExporterOptions):
         )
 
         # TODO(twata): Remove unnecessary outputs. Graph#eraseOutput isn't available
-        # while self.g.outputsSize() > len(self.outputs):
+        # while self.g.outputsSize() > len(self.flat_outputs):
         #     self.g.eraseOutput(self.g.outputsSize() - 1)
 
         self.optimize_onnx(self.g)
@@ -828,10 +830,8 @@ class _Exporter(_ExporterOptions):
             k = val_tab[_unique_id(v)]
             inout_names.append(k)
             onnx_outputs.append(onnx_value(v, k))
-            if idx < len(self.outputs):
-                if isinstance(self.outputs[idx], tuple):
-                    raise RuntimeError('Models returning nested lists/tuples are not supported yet')
-                _apply_tensor_info_to_value_info(onnx_outputs[-1], self.outputs[idx])
+            if idx < len(self.flat_outputs):
+                _apply_tensor_info_to_value_info(onnx_outputs[-1], self.flat_outputs[idx])
                 apply_dynamic_axes_info(onnx_outputs[-1], k)
 
         graph = onnx.helper.make_graph(
@@ -916,4 +916,4 @@ def export(
     ex = _Exporter(model, inputs=args, **kwargs)
     ex.generate(f)
 
-    return ex.outputs
+    return ex.original_outputs

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export.py
@@ -167,3 +167,20 @@ def test_norm():
             return torch.norm(x)
 
     run_model_test(Net(), (torch.rand(2, 3, 5, 7),), opset_version=13)
+
+
+@pytest.mark.filterwarnings("ignore::torch.jit.TracerWarning")
+@pytest.mark.filterwarnings("ignore:Exporting a model to ONNX with a batch_size other than 1.*:UserWarning")
+def test_nested():
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rnn = torch.nn.LSTM(13, 17, 2)
+            self.x = torch.nn.parameter.Parameter(torch.randn(3, 7, 13))
+
+        def forward(self, *hidden):
+            return self.rnn(self.x, tuple(hidden))
+
+    m = run_model_test(
+        Model(), (torch.randn(2, 7, 17), torch.randn(2, 7, 17)),
+        skip_oxrt=True, output_names=["a", "b", "c"])

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export.py
@@ -181,6 +181,6 @@ def test_nested():
         def forward(self, *hidden):
             return self.rnn(self.x, tuple(hidden))
 
-    m = run_model_test(
+    run_model_test(
         Model(), (torch.randn(2, 7, 17), torch.randn(2, 7, 17)),
         skip_oxrt=True, output_names=["a", "b", "c"])

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export.py
@@ -218,4 +218,3 @@ def test_custom_opsets():
     for o in m.opset_import:
         if o.domain == 'org.chainer':
             assert o.version == ver
-

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/utils.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/utils.py
@@ -41,6 +41,7 @@ def run_model_test(
         if not isinstance(expected, tuple):
             expected = (expected,)
 
+        te_model = None
         if check_torch_export:
             with tempfile.NamedTemporaryFile() as torch_f:
                 torch.onnx.export(
@@ -51,6 +52,8 @@ def run_model_test(
                     output_names=output_names,
                     **kwargs,
                 )
+                torch_f.flush()
+                te_model = onnx.load(torch_f.name)
 
         if input_names is None:
             input_names = [f"input_{idx}" for idx, _ in enumerate(args)]
@@ -70,7 +73,13 @@ def run_model_test(
         assert len(actual) == len(expected)
 
         for a, e in zip(actual, expected):
-            assert torch.isclose(a, e, rtol=rtol, atol=atol).all()
+            if isinstance(a, torch.Tensor) and isinstance(e, torch.Tensor):
+                assert torch.isclose(a, e, rtol=rtol, atol=atol).all()
+
+        pfto_model = onnx.load(f.name)
+        if te_model is not None:
+            assert len(te_model.graph.output) == len(pfto_model.graph.output)
+            assert len(te_model.graph.input) == len(pfto_model.graph.input)
 
         if skip_oxrt:
             return onnx.load(f.name)
@@ -81,4 +90,4 @@ def run_model_test(
             cmp = torch.isclose(torch.tensor(a), e.cpu(), rtol=rtol, atol=atol)
             assert cmp.all(), f"{cmp.logical_not().count_nonzero()} / {cmp.numel()} values failed"
 
-        return onnx.load(f.name)
+        return pfto_model

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/utils.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/utils.py
@@ -44,15 +44,15 @@ def run_model_test(
         te_model = None
         if check_torch_export:
             with tempfile.NamedTemporaryFile() as torch_f:
+                torch_f.close()
                 torch.onnx.export(
                     model,
                     args,
-                    torch_f,
+                    torch_f.name,
                     input_names=input_names,
                     output_names=output_names,
                     **kwargs,
                 )
-                torch_f.close()
                 te_model = onnx.load(torch_f.name)
 
         if input_names is None:
@@ -82,7 +82,7 @@ def run_model_test(
             assert len(te_model.graph.input) == len(pfto_model.graph.input)
 
         if skip_oxrt:
-            return onnx.load(f.name)
+            return pfto_model
 
         ort_session = ort.InferenceSession(f.name)
         actual = ort_session.run(None, {k: v.cpu().numpy() for k, v in zip(input_names, args)})

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/utils.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/utils.py
@@ -52,7 +52,7 @@ def run_model_test(
                     output_names=output_names,
                     **kwargs,
                 )
-                torch_f.flush()
+                torch_f.close()
                 te_model = onnx.load(torch_f.name)
 
         if input_names is None:


### PR DESCRIPTION
Ref: https://github.com/pfnet/pytorch-pfn-extras/pull/563
`prim::TupleConstruct` would be flattened by https://sourcegraph.com/github.com/pytorch/pytorch@77d29bcee200f04bece4a86283acfb8e1ec830ad/-/blob/torch/csrc/jit/passes/onnx/peephole.cpp?L765