### PR TITLE
[CI] Use cpu torch package instead

### DIFF
--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install
       run: |
         pip install -U pip wheel
-        pip install 'torch==${{ matrix.torch }}'
+        pip install 'torch==${{ matrix.torch }}' --extra-index-url https://download.pytorch.org/whl/cpu
         pip install -v -e .
         # Test PPE is importable with minimum dependency
         python -c 'import pytorch_pfn_extras'

--- a/.github/workflows/test-cpu.yml
+++ b/.github/workflows/test-cpu.yml
@@ -20,8 +20,7 @@ jobs:
     - name: Install
       run: |
         pip install -U pip wheel
-        pip install 'torch==1.9.*'
-        pip install 'torchvision==0.10.*'
+        pip install 'torch==1.9.*' 'torchvision==0.10.*' --extra-index-url https://download.pytorch.org/whl/cpu
         pip install pytest
         pip install matplotlib tensorboard ipython ipywidgets pandas optuna onnx onnxruntime pytorch-ignite
         pip install -v -e .


### PR DESCRIPTION
To reduce file download

`pip install torch` installs torch with cuda 10.2 support and it's more than 800MB
With `--extra-index-url https://download.pytorch.org/whl/cpu` option, it install cpu only support torch which is less than 200MB