### PR TITLE
[CI] Test with nightly torch daily

### DIFF
--- a/.github/workflows/nightly-test-cpu.yml
+++ b/.github/workflows/nightly-test-cpu.yml
@@ -1,0 +1,35 @@
+name: "Nightly CPU Tests"
+
+on:
+  schedule:
+  - cron: 0 0 * * *
+  workflow_dispatch: {}
+
+jobs:
+  nightly-test:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install
+      run: |
+        pip install -U pip wheel
+        pip install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+        pip install pytest
+        pip install matplotlib tensorboard ipython ipywidgets pandas optuna onnx onnxruntime pytorch-ignite
+        pip install -v -e .
+        # Test PPE is importable with minimum dependency
+        python -c 'import pytorch_pfn_extras'
+
+    - name: Test CPU only
+      run: |
+        pytest -m "not gpu" tests


### PR DESCRIPTION
By using nightly built torch wheel
With `workflow_dispatch` this job could be dispatched manually from actions tab. Ref: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow