### PR TITLE
Suppress jupyter warnings

### DIFF
--- a/.github/workflows/nightly-test-cpu.yml
+++ b/.github/workflows/nightly-test-cpu.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   nightly-test:
     runs-on: ubuntu-22.04
+    env:
+      JUPYTER_PLATFORM_DIRS: "1"
 
     steps:
     - name: Checkout

--- a/.github/workflows/test-cpu.yml
+++ b/.github/workflows/test-cpu.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-22.04
+    env:
+      JUPYTER_PLATFORM_DIRS: "1"
 
     steps:
     - name: Checkout


### PR DESCRIPTION
For `Jupyter is migrating its paths to use standard platformdirs` warnings

Ref https://github.com/jupyter/jupyter_core/pull/292