### PR TITLE
Fix CuPy import error in Pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -27,5 +27,9 @@ filterwarnings =
     ignore:Widget.widget_types is deprecated.:DeprecationWarning
     ignore:Widget._widget_types is deprecated.:DeprecationWarning
     ignore:Widget._active_widgets is deprecated.:DeprecationWarning
+    # For CuPy v11 & NumPy 1.24
+    ignore:.*`np.bool8` is a deprecated alias for:DeprecationWarning:
+    ignore:.*`np.int0` is a deprecated alias for:DeprecationWarning:
+    ignore:.*`np.uint0` is a deprecated alias for:DeprecationWarning:
 markers =
     gpu: Tests that require GPU


### PR DESCRIPTION
Fixes the CI errors by filtering the numpy 1.24 deprecation warnings.

This caused `pytest.importorskip('cupy')` to fail with a cryptic error ...

```
@cupy._util.memoize(for_each_device=True) 
E   AttributeError: partially initialized module 'cupy' has no attribute '_util' (most likely due to a circular import)
```