### PR TITLE
Fix notebook extension aliasing

### DIFF
--- a/pytorch_pfn_extras/training/extensions/__init__.py
+++ b/pytorch_pfn_extras/training/extensions/__init__.py
@@ -30,7 +30,7 @@ except ImportError:
     _ipython_module_available = False
 
 
-if _util._is_notebook():
+if _ipython_module_available and _util._is_notebook():
     PrintReport = PrintReportNotebook
     ProgressBar = ProgressBarNotebook
 else:


### PR DESCRIPTION
This fixes `NameError: name 'PrintReportNotebook' is not defined` error on import.
This situation may happen when ipykernel is used directly without installing `ipywidgets` (e.g., `#%%` cells by VS Code's Python extension).