### PR TITLE
Export control-flow Ops in ppe.onnx.export

### DIFF
--- a/pytorch_pfn_extras/onnx/__init__.py
+++ b/pytorch_pfn_extras/onnx/__init__.py
@@ -12,6 +12,7 @@ try:
     from pytorch_pfn_extras.onnx._grad import grad  # NOQA
     from pytorch_pfn_extras.onnx.load import load_model  # NOQA
     from pytorch_pfn_extras.onnx._helper import no_grad  # NOQA
+    import pytorch_pfn_extras.onnx._lax as lax  # NOQA
     available = True
 except ImportError:
     available = False

--- a/pytorch_pfn_extras/onnx/_as_output.py
+++ b/pytorch_pfn_extras/onnx/_as_output.py
@@ -105,7 +105,7 @@ class _ExplicitIdentity(torch.autograd.Function):
         ctx: Any,
         x: torch.Tensor,
     ) -> torch.Tensor:
-        return x
+        return x.clone()
 
     @staticmethod
     def backward(  # type: ignore

--- a/pytorch_pfn_extras/onnx/_as_output.py
+++ b/pytorch_pfn_extras/onnx/_as_output.py
@@ -119,7 +119,9 @@ class _ExplicitIdentity(torch.autograd.Function):
         return g.op("Identity", x)
 
 
-def as_output(name: str, value: torch.Tensor, add_identity: bool = True) -> torch.Tensor:
+def as_output(
+        name: str, value: torch.Tensor, add_identity: bool = True
+) -> torch.Tensor:
     if torch.jit.is_scripting():  # type: ignore[no-untyped-call]
         warnings.warn(
             '`as_output` seen in TorchScript compilation. The value is no '

--- a/pytorch_pfn_extras/onnx/_as_output.py
+++ b/pytorch_pfn_extras/onnx/_as_output.py
@@ -98,12 +98,37 @@ def trace(
         _outputs.outputs = None
 
 
-def as_output(name: str, value: torch.Tensor) -> torch.Tensor:
+# Add Identity function to prevent constant folding in torch.onnx
+class _ExplicitIdentity(torch.autograd.Function):
+    @staticmethod
+    def forward(  # type: ignore
+        ctx: Any,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        return x
+
+    @staticmethod
+    def backward(  # type: ignore
+        ctx: Any,
+        dx: torch.Tensor,
+    ) -> torch.Tensor:
+        return dx
+
+    @staticmethod
+    def symbolic(g, x):  # type: ignore
+        return g.op("Identity", x)
+
+
+def as_output(name: str, value: torch.Tensor, add_identity: bool = True) -> torch.Tensor:
     if torch.jit.is_scripting():  # type: ignore[no-untyped-call]
         warnings.warn(
             '`as_output` seen in TorchScript compilation. The value is no '
             'longer an output in the exported onnx.')
         return value
     if hasattr(_outputs, "outputs") and _outputs.outputs is not None:
+        if add_identity:
+            value = _ExplicitIdentity.apply(value)
         _outputs.outputs.add(name, value)
+        if add_identity:
+            value = _ExplicitIdentity.apply(value)
     return value

--- a/pytorch_pfn_extras/onnx/_grad.py
+++ b/pytorch_pfn_extras/onnx/_grad.py
@@ -46,7 +46,7 @@ def grad(
         for i, input in enumerate(inputs):
             input_name = f"Gradient_x_{i}_{n_grad_call}"
             input_names.append(input_name)
-            inputs_l[i] = as_output(input_name, input)
+            inputs_l[i] = as_output(input_name, input, add_identity=False)
 
         class _Gradient(torch.autograd.Function):
             @staticmethod

--- a/pytorch_pfn_extras/onnx/_lax.py
+++ b/pytorch_pfn_extras/onnx/_lax.py
@@ -1,4 +1,12 @@
-# equivalent to [jax.lax](https://jax.readthedocs.io/en/latest/jax.lax.html)
+"""
+This file provides APIs to define control-flow operators (e.g., onnx::Loop and onnx::If)
+when using `ppe.onnx.export`.
+`torch.jit` records only `first loop` during tracing, and ppe.onnx inserts control-flow
+operators after exporting ONNX.
+
+APIs are almost same as [jax.lax](https://jax.readthedocs.io/en/latest/jax.lax.html).
+"""
+
 import torch
 import threading
 import onnx

--- a/pytorch_pfn_extras/onnx/_lax.py
+++ b/pytorch_pfn_extras/onnx/_lax.py
@@ -1,0 +1,273 @@
+# equivalent to [jax.lax](https://jax.readthedocs.io/en/latest/jax.lax.html)
+import torch
+import threading
+import onnx
+import onnx.helper
+from typing import Generator, Callable, Any, List, Tuple
+from contextlib import contextmanager
+
+from pytorch_pfn_extras.onnx._as_output import as_output
+
+
+_lax_state = threading.local()
+
+# copy from https://github.com/pytorch/pytorch/blob/e180ca652f8a38c479a3eff1080efe69cbc11621/torch/testing/_internal/common_utils.py#L367
+_torch_dtype_to_onnx_dtype_dict = {
+    torch.bool: onnx.TensorProto.BOOL,
+    torch.uint8: onnx.TensorProto.UINT8,
+    torch.int8: onnx.TensorProto.INT8,
+    torch.int16: onnx.TensorProto.INT16,
+    torch.int32: onnx.TensorProto.INT32,
+    torch.int64: onnx.TensorProto.INT64,
+    torch.float16: onnx.TensorProto.FLOAT16,
+    torch.float32: onnx.TensorProto.FLOAT,
+    torch.float64: onnx.TensorProto.DOUBLE,
+    torch.complex64: onnx.TensorProto.COMPLEX64,
+    torch.complex128: onnx.TensorProto.COMPLEX128,
+}
+
+
+@contextmanager
+def init_lax_state() -> Generator[None, None, None]:
+    _lax_state.n_call = 0
+    _lax_state.input_for_postproc = {}
+    try:
+        yield
+    finally:
+        _lax_state.n_call = None
+        _lax_state.input_for_postproc = None
+
+
+# Add Identity function to prevent constant folding in torch.onnx
+class _ExplicitIdentity(torch.autograd.Function):
+    @staticmethod
+    def forward(  # type: ignore
+        ctx: Any,
+        it: torch.Tensor,
+    ) -> torch.Tensor:
+        return it
+
+    @staticmethod
+    def symbolic(g, it):  # type: ignore
+        return g.op("Identity", it)
+
+
+class _DummyForiLoop(torch.autograd.Function):
+    @staticmethod
+    def forward(  # type: ignore
+        ctx: Any,
+        init_val: torch.Tensor,
+        actual_val: torch.Tensor,
+    ) -> torch.Tensor:
+        return actual_val
+
+    @staticmethod
+    def symbolic(g, init_val, actual_val):  # type: ignore
+        return init_val
+
+
+def fori_loop(
+    lower: int, upper: int, body_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor], init_val: torch.Tensor
+) -> torch.Tensor:
+    def _run(lower: int, upper: int, init_val: torch.Tensor) -> torch.Tensor:
+        val = init_val
+        for i in range(lower, upper):
+            it = torch.full(size=(), fill_value=i)
+            val = body_fn(it, val)
+        return val
+
+    if torch.jit.is_tracing():  # type: ignore
+        if lower >= upper:
+            return init_val
+
+        err_msg = "ppe.onnx.jax.fori_loop() can only be used in conjunction " + \
+            "with export functions under ppe.onnx"
+        assert hasattr(_lax_state, "n_call"), err_msg
+        n_call = _lax_state.n_call
+        for_postproc = {
+            "type": "fori_loop",
+            "n_call": n_call,
+            "lower": lower,
+            "upper": upper,
+            "it_name": f"fori_loop_it_{n_call}",
+            "init_val_names": [f"fori_loop_prev_state_0_{n_call}"],
+            "val_names": [f"fori_loop_state_0_{n_call}"],
+            "val_dtypes": [_torch_dtype_to_onnx_dtype_dict[init_val.dtype]],
+        }
+        _lax_state.n_call += 1
+        _lax_state.input_for_postproc[n_call] = for_postproc
+
+        # trace first iteration
+        it = torch.full(size=(), fill_value=lower, dtype=torch.int64)
+        it = _ExplicitIdentity.apply(it)
+        it = as_output(for_postproc["it_name"], it)
+        init_val = _ExplicitIdentity.apply(init_val)
+        init_val = as_output(for_postproc["init_val_names"][0], init_val)
+        val = body_fn(it, init_val)
+        val = as_output(for_postproc["val_names"][0], val)
+        # use dummy function for other iterations
+        actual = _run(lower + 1, upper, val)
+        return _DummyForiLoop.apply(val, actual)
+    else:
+        return _run(lower, upper, init_val)
+
+
+def _make_constant_scalar(name: str, dtype: onnx.TensorProto.DataType, value: Any) -> onnx.NodeProto:
+    return onnx.helper.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=onnx.helper.make_tensor(
+            name="",
+            data_type=dtype,
+            dims=[],
+            vals=[value],
+        ),
+    )
+
+
+def _to_value_infos(names: List[str], dtypes: List[Any], shapes: List[Any]) -> List[onnx.TensorProto]:
+    return [
+        onnx.helper.make_tensor_value_info(name, dtype, shape)
+        for name, dtype, shape in zip(names, dtypes, shapes)
+    ]
+
+
+def _find_nodes(graph: onnx.GraphProto, in_names: List[str], out_names: List[str]) -> Tuple[int, List[onnx.NodeProto]]:
+    class HashableNode:
+        def __init__(self, node: onnx.NodeProto) -> None:
+            self.node = node
+
+        def __hash__(self) -> int:
+            return hash(str(self.node))
+
+        def __eq__(self, other: Any) -> bool:
+            if isinstance(other, HashableNode):
+                return self.node == other.node
+            return False
+
+    nodes = set()
+    visited = set()
+
+    name_to_nodes = {}
+    node_to_index = {}
+    for i, node in enumerate(graph.node):
+        node_to_index[HashableNode(node)] = i
+        for input in node.input:
+            if input not in name_to_nodes:
+                name_to_nodes[input] = []
+            name_to_nodes[input].append(node)
+
+    def _find_output_node(node: HashableNode) -> bool:
+        if node in visited:
+            return False
+
+        visited.add(node)
+        if len(set(node.node.output) & set(out_names)) != 0:
+            nodes.add(node)
+            return True
+        for output in node.node.output:
+            found = False
+            if output not in name_to_nodes:
+                continue
+            for next in name_to_nodes[output]:
+                if _find_output_node(HashableNode(next)):
+                    found = True
+                    break
+            if found:
+                nodes.add(node)
+                return True
+        return False
+
+    for node in graph.node:
+        if len(set(node.input) & set(in_names)) != 0:
+            nodes.add(HashableNode(node))
+            _find_output_node(HashableNode(node))
+        if len(set(node.output) & set(out_names)):
+            nodes.add(HashableNode(node))
+
+    idx = min([node_to_index[node] for node in nodes])
+
+    # sort by original order
+    node_sorted = [x.node for x in nodes]
+    node_sorted.sort(key=lambda node: node_to_index[HashableNode(node)])
+
+    return idx, node_sorted
+
+
+def postprocess(onnx_graph: onnx.ModelProto) -> None:
+    assert hasattr(_lax_state, "input_for_postproc")
+    for for_postproc in _lax_state.input_for_postproc.values():
+        if for_postproc["type"] == "fori_loop":
+            n_call = for_postproc["n_call"]
+            lower = for_postproc["lower"]
+            upper = for_postproc["upper"]
+            it_name = for_postproc["it_name"]
+            init_val_names = for_postproc["init_val_names"]
+            val_names = for_postproc["val_names"]
+            val_dtypes = for_postproc["val_dtypes"]
+
+            # Create input of Loop op
+            M_name = f"ppe_lax_Loop_{n_call}_M"
+            cond_name = f"ppe_lax_Loop_{n_call}_cond"
+            M_const_node = _make_constant_scalar(M_name, onnx.TensorProto.INT64, upper - lower)
+            cond_const_node = _make_constant_scalar(cond_name, onnx.TensorProto.BOOL, True)
+
+            # Create loop_body
+            cond_out_name = f"ppe_lax_Loop_{n_call}_cond_out"
+            cond_out_node = onnx.helper.make_node(
+                "Identity",
+                inputs=[cond_name],
+                outputs=[cond_out_name],
+                name=cond_out_name + "_Identity",
+            )
+            cnt_name = f"ppe_lax_Loop_{n_call}_cnt"
+            lower_name = f"ppe_lax_Loop_{n_call}_lower"
+            lower_node = _make_constant_scalar(lower_name, onnx.TensorProto.INT64, lower)
+            it_node = onnx.helper.make_node(
+                "Add",
+                inputs=[cnt_name, lower_name],
+                outputs=[it_name],
+                name=it_name + "_Add",
+            )
+            idx, nodes = _find_nodes(
+                onnx_graph.graph,
+                init_val_names + [it_name],
+                val_names,
+            )
+            loop_body = onnx.helper.make_graph(
+                nodes=[lower_node, it_node, ] + nodes + [cond_out_node],
+                name=f"ppe_lax_Loop_{n_call}_body",
+                inputs=_to_value_infos(
+                    [cnt_name, cond_name] + init_val_names,
+                    [onnx.TensorProto.INT64, onnx.TensorProto.BOOL] + val_dtypes,
+                    [(), ()] + [None] * len(init_val_names),
+                ),
+                outputs=_to_value_infos(
+                    [cond_out_name] + val_names,
+                    [onnx.TensorProto.BOOL] + val_dtypes,
+                    [()] + [None] * len(val_names),
+                ),
+            )
+            loop_node = onnx.helper.make_node(
+                name=f"ppe_lax_Loop_{n_call}",
+                op_type="Loop",
+                inputs=[M_name, cond_name] + init_val_names,
+                outputs=val_names,
+                body=loop_body,
+            )
+            assert len(nodes) != 0
+            onnx_graph.graph.node.insert(idx, M_const_node)
+            onnx_graph.graph.node.insert(idx + 1, cond_const_node)
+            onnx_graph.graph.node.insert(idx + 2, loop_node)
+            onnx_graph.graph.node.insert(idx, _make_constant_scalar("/Constant_output_0", onnx.TensorProto.BOOL, True))
+            for node in nodes:
+                onnx_graph.graph.node.remove(node)
+            for node in onnx_graph.graph.node:
+                if it_name in node.output:
+                    onnx_graph.graph.node.remove(node)
+            for output in list(onnx_graph.graph.output):
+                if output.name in val_names or output.name in init_val_names or output.name == it_name:
+                    onnx_graph.graph.output.remove(output)
+        else:
+            raise RuntimeError("Invalid lax type: " + for_postproc["type"])

--- a/pytorch_pfn_extras/onnx/_lax.py
+++ b/pytorch_pfn_extras/onnx/_lax.py
@@ -92,7 +92,9 @@ def _trace() -> bool:
     return True
 
 
-def _create_and_register_postproc(create_postproc: Callable[[int], Dict[str, Any]]) -> None:
+def _create_and_register_postproc(
+        create_postproc: Callable[[int], Dict[str, Any]]
+) -> Dict[str, Any]:
     n_call = _lax_state.n_call
     for_postproc = create_postproc(n_call)
     _lax_state.n_call += 1

--- a/pytorch_pfn_extras/onnx/_lax.py
+++ b/pytorch_pfn_extras/onnx/_lax.py
@@ -36,6 +36,7 @@ _torch_dtype_to_onnx_dtype_dict = {
 
 @contextmanager
 def init_lax_state() -> Generator[None, None, None]:
+    # `n_call` attribute is to avoid duplicate name created by as_output
     _lax_state.n_call = 0
     _lax_state.input_for_postproc = {}
     _lax_state.ignore_trace = False

--- a/pytorch_pfn_extras/onnx/_lax.py
+++ b/pytorch_pfn_extras/onnx/_lax.py
@@ -281,13 +281,13 @@ def cond(
             out_false, lambda i, val: as_output(for_postproc["false_names"][i], val)
         )
         if pred:
-            out = out_true
+            _out = out_true
         else:
-            out = out_false
-        out = _apply(out, lambda i, val: as_output(for_postproc["out_names"][i], val))
+            _out = out_false
+        _out = _apply(_out, lambda i, val: as_output(for_postproc["out_names"][i], val))
         out: List[torch.Tensor] = [
             _DummyOpForControlFlow.apply(v, act)
-            for v, act in zip(_as_tuple(out), _as_tuple(actual))
+            for v, act in zip(_as_tuple(_out), _as_tuple(actual))
         ]
         if is_tensor_state:
             return out[0]

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_as_output.py
@@ -13,6 +13,23 @@ from pytorch_pfn_extras.onnx import as_output
 from pytorch_pfn_extras_tests.onnx_tests.test_export_testcase import _helper
 
 
+def _get_name(onnx_graph: onnx.GraphProto, output_name: str):
+    in_name = None
+    out_name = None
+
+    for node in onnx_graph.node:
+        if node.output[0] == output_name:
+            assert node.op_type == "Identity"
+            in_name = node.input[0]
+        if node.input[0] == output_name:
+            assert node.op_type == "Identity"
+            out_name = node.output[0]
+
+    assert in_name is not None
+    assert out_name is not None
+    return in_name, out_name
+
+
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_as_output_no_export():
     if not pytorch_pfn_extras.requires("1.8.0"):
@@ -60,13 +77,78 @@ def test_as_output():
     actual_onnx = onnx.load(os.path.join(output_dir, 'model.onnx'))
     named_nodes = {n.name: n for n in actual_onnx.graph.node}
     assert 'Conv_0' in named_nodes
-    assert 'MatMul_2' in named_nodes
+    assert 'MatMul_4' in named_nodes
 
     outputs = list([v.name for v in actual_onnx.graph.output])
     assert len(outputs) == 2
     assert outputs[1] == "h"
-    assert named_nodes["Conv_0"].output[0] == "h"
-    assert named_nodes["MatMul_2"].input[0] == "h"
+    in_name, out_name = _get_name(actual_onnx.graph, "h")
+    assert named_nodes["Conv_0"].output[0] == in_name
+    assert named_nodes["MatMul_4"].input[0] == out_name
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_as_output_to_input():
+    if not pytorch_pfn_extras.requires("1.8.0"):
+        pytest.skip('skip for PyTorch 1.7 or earlier')
+
+    class Net(nn.Module):
+        def __init__(self):
+            super(Net, self).__init__()
+            self.conv = nn.Conv2d(1, 6, 3)
+            self.linear = nn.Linear(30, 20, bias=False)
+
+        def forward(self, x):
+            x = as_output("x", x)
+            h = self.conv(x)
+            h = self.linear(h)
+            return h
+
+    model = Net()
+    x = torch.ones((1, 1, 32, 32))
+    output_dir = _helper(model, x, 'as_output')
+
+    actual_onnx = onnx.load(os.path.join(output_dir, 'model.onnx'))
+    named_nodes = {n.name: n for n in actual_onnx.graph.node}
+    assert 'Conv_2' in named_nodes
+
+    outputs = list([v.name for v in actual_onnx.graph.output])
+    assert len(outputs) == 2
+    assert outputs[1] == "x"
+    _, out_name = _get_name(actual_onnx.graph, "x")
+    assert named_nodes["Conv_2"].input[0] == out_name
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_as_output_to_output():
+    if not pytorch_pfn_extras.requires("1.8.0"):
+        pytest.skip('skip for PyTorch 1.7 or earlier')
+
+    class Net(nn.Module):
+        def __init__(self):
+            super(Net, self).__init__()
+            self.conv = nn.Conv2d(1, 6, 3)
+            self.linear = nn.Linear(30, 20, bias=False)
+
+        def forward(self, x):
+            h = self.conv(x)
+            h = self.linear(h)
+            h = as_output("out", h)
+            return h
+
+    model = Net()
+    x = torch.ones((1, 1, 32, 32))
+    output_dir = _helper(model, x, 'as_output')
+
+    actual_onnx = onnx.load(os.path.join(output_dir, 'model.onnx'))
+    named_nodes = {n.name: n for n in actual_onnx.graph.node}
+    assert 'MatMul_2' in named_nodes
+
+    outputs = list([v.name for v in actual_onnx.graph.output])
+    assert len(outputs) == 2
+    assert outputs[1] == "out"
+    in_name, _ = _get_name(actual_onnx.graph, "out")
+    assert named_nodes["MatMul_2"].output[0] == in_name
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
@@ -61,7 +61,7 @@ def test_grad_no_export():
     assert y.shape == (1, 1, 32, 20)
 
 
-@pytest.mark.filterwarnings("ignore:The shape inference of ai.onnx.preview..Gradient type is missing:UserWarning")
+@pytest.mark.filterwarnings("ignore:Converting a tensor:")
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_grad():
     if not pytorch_pfn_extras.requires('1.8.0'):

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
@@ -60,6 +60,7 @@ def test_grad_no_export():
     y = model(x)
     assert y.shape == (1, 1, 32, 20)
 
+
 @pytest.mark.filterwarnings("ignore:The shape inference of ai.onnx.preview..Gradient type is missing:UserWarning")
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_grad():

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
@@ -107,8 +107,8 @@ def test_grad():
         assert '/_ppe_as_out_module/linear/MatMul' in named_nodes
     else:
         assert 'Conv_2' in named_nodes
-        assert 'Gradient_3' in named_nodes
-        assert 'MatMul_5' in named_nodes
+        assert 'Gradient_4' in named_nodes
+        assert 'MatMul_6' in named_nodes
 
     assert list([v.name for v in actual_onnx.graph.output]) == [
         "v10_MatMul", "Gradient_y_0", "Gradient_x_0_0"
@@ -179,10 +179,10 @@ def test_grad_multiple_times():
         assert '/_ppe_as_out_module/linear/MatMul' in named_nodes
     else:
         assert 'Conv_2' in named_nodes
-        assert 'Conv_6' in named_nodes
-        assert 'Gradient_3' in named_nodes
-        assert 'Gradient_7' in named_nodes
-        assert 'MatMul_10' in named_nodes
+        assert 'Conv_7' in named_nodes
+        assert 'Gradient_4' in named_nodes
+        assert 'Gradient_9' in named_nodes
+        assert 'MatMul_12' in named_nodes
 
     assert list([v.name for v in actual_onnx.graph.output]) == [
         "v16_MatMul", "Gradient_y_0", "Gradient_x_0_0", "Gradient_y_1", "Gradient_x_0_1"
@@ -197,8 +197,8 @@ def test_grad_multiple_times():
     else:
         assert named_nodes["Conv_2"].input[0] == "Gradient_x_0_0"
         assert named_nodes["Conv_2"].output[0] == y0_in
-        assert named_nodes["Conv_6"].input[0] == "Gradient_x_0_1"
-        assert named_nodes["Conv_6"].output[0] == y1_in
+        assert named_nodes["Conv_7"].input[0] == "Gradient_x_0_1"
+        assert named_nodes["Conv_7"].output[0] == y1_in
 
 
 @pytest.mark.filterwarnings("ignore:The shape inference of ai.onnx.preview..Gradient type is missing:UserWarning")
@@ -249,8 +249,8 @@ def test_grad_with_multiple_inputs():
         assert '/_ppe_as_out_module/linear/MatMul' in named_nodes
     else:
         assert 'Conv_5' in named_nodes
-        assert 'Gradient_6' in named_nodes
-        assert 'MatMul_8' in named_nodes
+        assert 'Gradient_7' in named_nodes
+        assert 'MatMul_9' in named_nodes
 
     assert list([v.name for v in actual_onnx.graph.output]) == [
         "v14_MatMul", "Gradient_y_0", "Gradient_x_0_0", "Gradient_x_1_0"

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_grad.py
@@ -60,8 +60,7 @@ def test_grad_no_export():
     y = model(x)
     assert y.shape == (1, 1, 32, 20)
 
-
-@pytest.mark.filterwarnings("ignore:Converting a tensor:")
+@pytest.mark.filterwarnings("ignore:The shape inference of ai.onnx.preview..Gradient type is missing:UserWarning")
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_grad():
     if not pytorch_pfn_extras.requires('1.8.0'):

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_lax.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_lax.py
@@ -199,6 +199,85 @@ def test_while_loop():
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_cond_no_export():
+    if not pytorch_pfn_extras.requires('1.8.0'):
+        pytest.skip('skip for PyTorch 1.7 or earlier')
+
+    if pytorch_pfn_extras.requires('1.10.0') and sys.platform == 'win32':
+        pytest.skip('ONNX grad test does not work in windows CI for torch >= 1.10')
+
+    class Net(nn.Module):
+        def __init__(self):
+            super(Net, self).__init__()
+            self.linear = nn.Linear(1, 1)
+            self.linear.weight.data[:] = 2
+            self.linear.bias.data[:] = 3
+
+        def forward(self, x):
+            def true_fn(x):
+                return self.linear(x)
+
+            def false_fn(x):
+                return -x
+
+            h = lax.cond(x.sum().long() % 2 == 0, true_fn, false_fn, x)
+            return h
+
+    model = Net()
+    x = torch.tensor([[0], [1]]).float()
+    out = model(x)
+    assert out[0] == 0
+    assert out[1] == -1
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:Converting a tensor to a Python boolean might cause the trace to be incorrect:torch.jit.TracerWarning")
+def test_cond():
+    if not pytorch_pfn_extras.requires('1.8.0'):
+        pytest.skip('skip for PyTorch 1.7 or earlier')
+
+    if pytorch_pfn_extras.requires('1.10.0') and sys.platform == 'win32':
+        pytest.skip('ONNX grad test does not work in windows CI for torch >= 1.10')
+
+    class Net(nn.Module):
+        def __init__(self):
+            super(Net, self).__init__()
+            self.linear = nn.Linear(1, 1)
+            self.linear.weight.data[:] = 2
+            self.linear.bias.data[:] = 3
+
+        def forward(self, x):
+            def true_fn(x):
+                return self.linear(x)
+
+            def false_fn(x):
+                return -x
+
+            x = self.linear(x)
+            h = lax.cond(x.sum().long() % 2 == 0, true_fn, false_fn, x)
+            return h
+
+    model = Net()
+    x = torch.tensor([[0], [1]]).float()
+    output_dir = _helper(
+        model,
+        x,
+        'cond',
+        input_names=("x",),
+        enable_onnx_checker=False,
+        use_pfto=False,
+        do_constant_folding=False,
+    )
+
+    actual_onnx = onnx.load(os.path.join(output_dir, 'model.onnx'))
+    assert len([x for x in actual_onnx.graph.node if x.op_type == "If"]) == 1
+    ort_session = ort.InferenceSession(os.path.join(output_dir, "model.onnx"))
+    actual = ort_session.run(None, {"x": x.cpu().numpy()})
+    expected = model(x)
+    torch.testing.assert_close(expected, torch.tensor(actual[0]))
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_lax_multiple_times():
     if not pytorch_pfn_extras.requires('1.8.0'):
         pytest.skip('skip for PyTorch 1.7 or earlier')

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_lax.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_lax.py
@@ -1,0 +1,78 @@
+import os
+import sys
+
+import onnxruntime as ort
+import pytest
+import pytorch_pfn_extras
+import torch
+import torch.nn as nn
+import torch.onnx
+
+from pytorch_pfn_extras.onnx import lax
+from pytorch_pfn_extras_tests.onnx_tests.test_export_testcase import _helper
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_fori_loop_no_export():
+    if not pytorch_pfn_extras.requires("1.8.0"):
+        pytest.skip('skip for PyTorch 1.7 or earlier')
+
+    torch.manual_seed(0)
+
+    class Net(nn.Module):
+        def __init__(self):
+            super(Net, self).__init__()
+            self.linear = nn.Linear(1, 1)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            x = x * 0.5
+            h = lax.fori_loop(1, 4, lambda it, val: it * self.relu(self.linear(val)), x)
+            return h + 1
+
+    model = Net()
+    x = torch.ones((1, 1))
+    y = model(x)
+    v = x * 0.5
+    for i in range(1, 4):
+        v = i * model.relu(model.linear(v))
+    y_expected = v + 1
+    torch.testing.assert_close(y, y_expected)
+
+
+@pytest.mark.filterwarnings("ignore:The shape inference of ai.onnx.preview..Gradient type is missing:UserWarning")
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_fori_loop():
+    if not pytorch_pfn_extras.requires('1.8.0'):
+        pytest.skip('skip for PyTorch 1.7 or earlier')
+
+    if pytorch_pfn_extras.requires('1.10.0') and sys.platform == 'win32':
+        pytest.skip('ONNX grad test does not work in windows CI for torch >= 1.10')
+
+    class Net(nn.Module):
+        def __init__(self):
+            super(Net, self).__init__()
+            self.linear = nn.Linear(1, 1)
+            self.linear.weight.data[:] = 2
+            self.linear.bias.data[:] = 3
+
+        def forward(self, x):
+            x = x * 0.5
+            h = lax.fori_loop(1, 4, lambda it, val: it * self.linear(val) + 0.5, x)
+            return h + 1
+
+    model = Net()
+    x = torch.ones(1, 1)
+    output_dir = _helper(
+        model,
+        x,
+        'fori_loop',
+        enable_onnx_checker=False,
+        use_pfto=False,
+        do_constant_folding=False,
+    )
+
+    ort_session = ort.InferenceSession(os.path.join(output_dir, "model.onnx"))
+    actual = ort_session.run(None, {"input_0": x.cpu().numpy()})
+    expected = model(x)
+    torch.testing.assert_close(expected, torch.tensor(actual[0]))

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_lax.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_lax.py
@@ -370,7 +370,3 @@ def test_lax_nested():
     actual = ort_session.run(None, {"x": x.cpu().numpy()})
     expected = model(x)
     torch.testing.assert_close(expected, torch.tensor(actual[0]))
-
-
-if __name__ == "__main__":
-    test_while_loop()


### PR DESCRIPTION
Add functions to represent control flows in [jax.lax](https://jax.readthedocs.io/en/latest/jax.lax.html) (`fori_loop`, `while_loop`, `cond`)

These functions trace only first iteration, then `ppe.onnx` inserts `onnx::Loop` or `onnx::If` operators to an exported ONNX as postprocess.