### PR TITLE
Also look for snapshot in ``writer.out_dir``

### DIFF
--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -337,7 +337,6 @@ class _Snapshot(extension.Extension):
     def initialize(  # type: ignore[override]
             self, manager: ExtensionsManagerProtocol) -> Optional[str]:
         target = manager if self._target is None else self._target
-        outdir = manager.out
         writer = manager.writer if self.writer is None else self.writer
         self.writer = writer
         loaded_fn = None
@@ -376,10 +375,10 @@ class _Snapshot(extension.Extension):
             # injected here.
             def _cleanup() -> None:
                 assert writer is not None
-                files = _find_stale_snapshots(self.filename, outdir,
+                files = _find_stale_snapshots(self.filename, writer.out_dir,
                                               self.n_retains, writer.fs)
                 for file in files:
-                    writer.fs.remove(os.path.join(outdir, file))
+                    writer.fs.remove(os.path.join(writer.out_dir, file))
 
             assert writer is not None
             writer._add_cleanup_hook(_cleanup)

--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -342,7 +342,7 @@ class _Snapshot(extension.Extension):
         self.writer = writer
         loaded_fn = None
         if self.autoload:
-            # If ``autoload`` is on, this code scans the ``outdir``
+            # If ``autoload`` is on, this code scans the ``writer.out_dir``
             # for potential snapshot files by matching the file names
             # from ``filename`` format, picks up the latest one in
             # terms of mtime, and tries to load it it the target or

--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -349,6 +349,9 @@ class _Snapshot(extension.Extension):
             # manager.
             assert writer is not None
             loaded_fn = _find_latest_snapshot(self.filename, outdir, writer.fs)
+            if not loaded_fn:
+                # Try searching in ``writer.out_dir`` if there is no snapshot in ``outdir``
+                loaded_fn = _find_latest_snapshot(self.filename, writer.out_dir, writer.fs)
             if loaded_fn:
                 snapshot_file = writer.fs.open(os.path.join(outdir, loaded_fn), 'rb')
                 # As described above (at ``autoload`` option),

--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -348,10 +348,9 @@ class _Snapshot(extension.Extension):
             # terms of mtime, and tries to load it it the target or
             # manager.
             assert writer is not None
-            loaded_fn = _find_latest_snapshot(self.filename, outdir, writer.fs)
+            loaded_fn = _find_latest_snapshot(self.filename, writer.out_dir, writer.fs)
             if not loaded_fn:
-                # Try searching in ``writer.out_dir`` if there is no snapshot in ``outdir``
-                loaded_fn = _find_latest_snapshot(self.filename, writer.out_dir, writer.fs)
+                loaded_fn = _find_latest_snapshot(self.filename, outdir, writer.fs)
             if loaded_fn:
                 snapshot_file = writer.fs.open(os.path.join(outdir, loaded_fn), 'rb')
                 # As described above (at ``autoload`` option),

--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -349,10 +349,8 @@ class _Snapshot(extension.Extension):
             # manager.
             assert writer is not None
             loaded_fn = _find_latest_snapshot(self.filename, writer.out_dir, writer.fs)
-            if not loaded_fn:
-                loaded_fn = _find_latest_snapshot(self.filename, outdir, writer.fs)
             if loaded_fn:
-                snapshot_file = writer.fs.open(os.path.join(outdir, loaded_fn), 'rb')
+                snapshot_file = writer.fs.open(os.path.join(writer.out_dir, loaded_fn), 'rb')
                 # As described above (at ``autoload`` option),
                 # snapshot files to be autoloaded must be saved by
                 # ``save_npz`` . In order to support general format,

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
@@ -335,6 +335,53 @@ def test_remove_stale_snapshots(path):
     snapshot2.initialize(trainer2)
 
 
+def test_remove_stale_snapshots_with_writer(path, snapshot_path):
+    fmt = 'snapshot_iter_{.iteration}'
+    retain = 3
+    snapshot = extensions.snapshot(filename=fmt, n_retains=retain,
+                                   writer=ppe.writing.SimpleWriter(out_dir=snapshot_path),
+                                   autoload=False)
+
+    trainer = get_trainer(out_dir=path)
+    trainer.extend(snapshot, trigger=(1, 'iteration'), priority=2)
+
+    class TimeStampUpdater(training.Extension):
+        t = time.time() - 100
+        name = 'ts_updater'
+        priority = 1  # This must be called after snapshot taken
+
+        def __call__(self, _trainer):
+            filename = os.path.join(snapshot_path, fmt.format(_trainer))
+            self.t += 1
+            # For filesystems that does low timestamp precision
+            os.utime(filename, (self.t, self.t))
+
+    trainer.extend(TimeStampUpdater(), trigger=(1, 'iteration'))
+    for _ in range(10):
+        with trainer.run_iteration():
+            pass
+    assert 10 == trainer.iteration
+
+    pattern = os.path.join(path, "snapshot_iter_*")
+    found = [os.path.basename(path) for path in glob.glob(pattern)]
+    assert len(found) == 0
+
+    pattern = os.path.join(snapshot_path, "snapshot_iter_*")
+    found = [os.path.basename(path) for path in glob.glob(pattern)]
+    assert retain == len(found)
+    found.sort()
+    # snapshot_iter_(8, 9, 10) expected
+    expected = ['snapshot_iter_{}'.format(i) for i in range(8, 11)]
+    expected.sort()
+    assert expected == found
+
+    trainer2 = get_trainer(
+        out_dir=path, state_to_load=trainer.state_dict())
+    snapshot2 = extensions.snapshot(filename=fmt, autoload=True, writer=ppe.writing.SimpleWriter(out_dir=snapshot_path))
+    # Just making sure no error occurs
+    snapshot2.initialize(trainer2)
+
+
 class Wrapper(torch.nn.Module):
     def __init__(self, model):
         super().__init__()

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot.py
@@ -399,7 +399,7 @@ def test_snapshot_autoload_initialize_without_writer(path):
 
     snapshot = extensions.snapshot(filename=snapshot_filename)
     snapshot(trainer)
-    assert os.path.isfile(f"{path}/{snapshot_filename}")
+    assert os.path.isfile(os.path.join(path, snapshot_filename))
 
     trainer2 = get_trainer(out_dir=path)
     snapshot2 = extensions.snapshot(filename=snapshot_filename, autoload=True)
@@ -416,8 +416,8 @@ def test_snapshot_autoload_with_writer(path, snapshot_path):
 
     snapshot = extensions.snapshot(filename=snapshot_filename, writer=ppe.writing.SimpleWriter(out_dir=snapshot_path))
     snapshot(trainer)
-    assert os.path.isfile(f"{snapshot_path}/{snapshot_filename}")
-    assert not os.path.isfile(f"{path}/{snapshot_filename}")
+    assert os.path.isfile(os.path.join(snapshot_path, snapshot_filename))
+    assert not os.path.isfile(os.path.join(path, snapshot_filename))
 
     trainer2 = get_trainer(out_dir=path, epochs=0)
     snapshot2 = extensions.snapshot(filename=snapshot_filename, writer=ppe.writing.SimpleWriter(out_dir=snapshot_path), autoload=True)


### PR DESCRIPTION
We save our snapshots in `snapshot` sub-directory under `outdir`. When we set our snapshot directory to `writer.out_dir`, the snapshots are saved properly but never got loaded.