### PR TITLE
Ignore scalar deprecation warning in NumPy 1.25

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -33,5 +33,6 @@ filterwarnings =
     ignore:.*`np.uint0` is a deprecated alias for:DeprecationWarning:
     # For CPU tests
     ignore:User provided device_type of 'cuda', but CUDA is not available. Disabling:UserWarning
+    ignore:.*Conversion of an array with ndim > 0 to a scalar is deprecated:DeprecationWarning
 markers =
     gpu: Tests that require GPU


### PR DESCRIPTION
tensorboard convert values to numpy arrays internally, so this deprecation warning is triggered by tensorboard and not ppe/pytorch