### PR TITLE
Remove no use out_dir

### DIFF
--- a/pytorch_pfn_extras/training/extensions/_snapshot.py
+++ b/pytorch_pfn_extras/training/extensions/_snapshot.py
@@ -444,9 +444,8 @@ class _Snapshot(extension.Extension):
             filename = filename(manager)
         else:
             filename = filename.format(manager)
-        outdir = manager.out
         writer(  # type: ignore
-            filename, outdir, serialized_target, savefun=self._savefun
+            filename, serialized_target, savefun=self._savefun
         )
 
     def finalize(self, manager: ExtensionsManagerProtocol) -> None:

--- a/pytorch_pfn_extras/training/extensions/log_report.py
+++ b/pytorch_pfn_extras/training/extensions/log_report.py
@@ -223,11 +223,9 @@ class LogReport(extension.Extension):
 
             # write to the log file
             log_name = self._filename.format(**stats_cpu)
-            out = manager.out
             savefun = LogWriterSaveFunc(self._format, self._append)
             writer(
                 log_name,
-                out,
                 self._log_looker.get(),
                 savefun=savefun,
                 append=self._append,

--- a/pytorch_pfn_extras/training/extensions/profile_report.py
+++ b/pytorch_pfn_extras/training/extensions/profile_report.py
@@ -131,7 +131,6 @@ class ProfileReport(extension.Extension):
                 )
                 writer(
                     log_name,
-                    out,
                     self._log,  # type: ignore
                     savefun=savefun,
                     append=self._append,

--- a/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
+++ b/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
@@ -453,7 +453,6 @@ grid=True)
 
         writer(
             self._filename,
-            manager.out,
             (fig, plt),  # type: ignore
             savefun=matplotlib_savefun,
         )

--- a/pytorch_pfn_extras/writing/_parallel_writer.py
+++ b/pytorch_pfn_extras/writing/_parallel_writer.py
@@ -34,16 +34,13 @@ class ThreadWriter(StandardWriter[threading.Thread]):
     def _save_with_exitcode(
         self,
         filename: str,
-        out_dir: str,
         target: _TargetType,
         savefun: _SaveFun,
         append: bool,
         **savefun_kwargs: Any,
     ) -> None:
         try:
-            self.save(
-                filename, out_dir, target, savefun, append, **savefun_kwargs
-            )
+            self.save(filename, target, savefun, append, **savefun_kwargs)
         except Exception as e:
             thread = threading.current_thread()
             thread.exitcode = -1  # type: ignore[attr-defined]
@@ -56,7 +53,6 @@ class ThreadWriter(StandardWriter[threading.Thread]):
     def create_worker(
         self,
         filename: str,
-        out_dir: str,
         target: _TargetType,
         *,
         savefun: Optional[_SaveFun] = None,
@@ -65,7 +61,7 @@ class ThreadWriter(StandardWriter[threading.Thread]):
     ) -> threading.Thread:
         return threading.Thread(
             target=self._save_with_exitcode,
-            args=(filename, out_dir, target, savefun, append),
+            args=(filename, target, savefun, append),
             kwargs=savefun_kwargs,
         )
 
@@ -97,7 +93,6 @@ class ProcessWriter(StandardWriter[multiprocessing.Process]):
     def create_worker(
         self,
         filename: str,
-        out_dir: str,
         target: _TargetType,
         *,
         savefun: Optional[_SaveFun] = None,
@@ -106,6 +101,6 @@ class ProcessWriter(StandardWriter[multiprocessing.Process]):
     ) -> multiprocessing.Process:
         return multiprocessing.Process(
             target=self.save,
-            args=(filename, out_dir, target, savefun, append),
+            args=(filename, target, savefun, append),
             kwargs=savefun_kwargs,
         )

--- a/pytorch_pfn_extras/writing/_queue_writer.py
+++ b/pytorch_pfn_extras/writing/_queue_writer.py
@@ -14,9 +14,7 @@ from pytorch_pfn_extras.writing._writer_base import (
     _Worker,
 )
 
-_QueUnit = Optional[
-    Tuple[_TaskFun, str, str, _TargetType, Optional[_SaveFun], bool]
-]
+_QueUnit = Optional[Tuple[_TaskFun, str, _TargetType, Optional[_SaveFun], bool]]
 
 
 class QueueWriter(Writer, Generic[_Worker]):
@@ -66,16 +64,13 @@ class QueueWriter(Writer, Generic[_Worker]):
     def __call__(
         self,
         filename: str,
-        out_dir: str,
         target: _TargetType,
         *,
         savefun: Optional[_SaveFun] = None,
         append: bool = False,
     ) -> None:
         assert not self._finalized
-        self._queue.put(
-            (self._task, filename, out_dir, target, savefun, append)
-        )
+        self._queue.put((self._task, filename, target, savefun, append))
 
     def create_task(self, savefun: _SaveFun) -> _TaskFun:
         return SimpleWriter(savefun=savefun)
@@ -93,9 +88,7 @@ class QueueWriter(Writer, Generic[_Worker]):
                 q.task_done()
                 return
             else:
-                task[0](
-                    task[1], task[2], task[3], savefun=task[4], append=task[5]
-                )
+                task[0](task[1], task[2], savefun=task[3], append=task[4])
                 q.task_done()
 
     def finalize(self) -> None:

--- a/pytorch_pfn_extras/writing/_simple_writer.py
+++ b/pytorch_pfn_extras/writing/_simple_writer.py
@@ -44,7 +44,6 @@ class SimpleWriter(Writer):
     def __call__(
         self,
         filename: str,
-        out_dir: str,
         target: _TargetType,
         *,
         savefun: Optional[_SaveFun] = None,
@@ -52,4 +51,4 @@ class SimpleWriter(Writer):
     ) -> None:
         if savefun is None:
             savefun = self._savefun
-        self.save(filename, out_dir, target, savefun, append, **self._kwds)
+        self.save(filename, target, savefun, append, **self._kwds)

--- a/pytorch_pfn_extras/writing/_tensorboard_writer.py
+++ b/pytorch_pfn_extras/writing/_tensorboard_writer.py
@@ -51,7 +51,6 @@ class TensorBoardWriter(object):
     def __call__(
         self,
         filename: str,
-        out_dir: str,
         target: _TargetType,
         *,
         savefun: Optional[_SaveFun] = None,

--- a/pytorch_pfn_extras/writing/_writer_base.py
+++ b/pytorch_pfn_extras/writing/_writer_base.py
@@ -235,7 +235,6 @@ class Writer:
     def __call__(
         self,
         filename: str,
-        out_dir: str,
         target: _TargetType,
         *,
         savefun: Optional[_SaveFun] = None,
@@ -280,7 +279,6 @@ class Writer:
     def save(
         self,
         filename: str,
-        out_dir: str,
         target: _TargetType,
         savefun: _SaveFun,
         append: bool,
@@ -375,7 +373,6 @@ class StandardWriter(Writer, Generic[_Worker]):
     def __call__(
         self,
         filename: str,
-        out_dir: str,
         target: _TargetType,
         *,
         savefun: Optional[_SaveFun] = None,
@@ -389,7 +386,6 @@ class StandardWriter(Writer, Generic[_Worker]):
         self._filename = filename
         self._worker = self.create_worker(
             filename,
-            out_dir,
             target,
             savefun=savefun,
             append=append,
@@ -402,7 +398,6 @@ class StandardWriter(Writer, Generic[_Worker]):
     def create_worker(
         self,
         filename: str,
-        out_dir: str,
         target: _TargetType,
         *,
         savefun: Optional[_SaveFun] = None,

--- a/tests/pytorch_pfn_extras_tests/test_writing.py
+++ b/tests/pytorch_pfn_extras_tests/test_writing.py
@@ -15,7 +15,7 @@ def test_tensorboard_writing():
         writer = ppe.writing.TensorBoardWriter(
             out_dir=tempd, filename_suffix="_test"
         )
-        writer(None, None, data)
+        writer(None, data)
         # Check that the file was generated
         for snap in os.listdir(tempd):
             assert "_test" in snap

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot_writers.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_snapshot_writers.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import os
 import tempfile
 import threading
 from unittest import mock
@@ -11,10 +12,12 @@ spshot_writers_path = "pytorch_pfn_extras.writing"
 
 def test_simple_writer():
     target = mock.MagicMock()
-    w = writing.SimpleWriter(foo=True)
     savefun = mock.MagicMock()
     with tempfile.TemporaryDirectory() as tempd:
-        w("myfile.dat", tempd, target, savefun=savefun)
+        w = writing.SimpleWriter(foo=True, out_dir=tempd)
+        filename = "myfile.dat"
+        w(filename, target, savefun=savefun)
+        assert os.path.exists(os.path.join(tempd, filename))
     assert savefun.call_count == 1
     assert savefun.call_args[0][0] == target
     assert savefun.call_args[1]["foo"] is True
@@ -22,14 +25,14 @@ def test_simple_writer():
 
 def test_standard_writer():
     target = mock.MagicMock()
-    w = writing.StandardWriter()
     worker = mock.MagicMock()
     worker.exitcode = 0
     name = spshot_writers_path + ".StandardWriter.create_worker"
     with mock.patch(name, return_value=worker):
         with tempfile.TemporaryDirectory() as tempd:
-            w("myfile.dat", tempd, target)
-            w("myfile.dat", tempd, target)
+            w = writing.StandardWriter(out_dir=tempd)
+            w("myfile.dat", target)
+            w("myfile.dat", target)
             w.finalize()
 
         assert worker.start.call_count == 2
@@ -38,36 +41,36 @@ def test_standard_writer():
 
 def test_thread_writer_create_worker():
     target = mock.MagicMock()
-    w = writing.ThreadWriter()
     with tempfile.TemporaryDirectory() as tempd:
-        worker = w.create_worker("myfile.dat", tempd, target, append=False)
+        w = writing.ThreadWriter(out_dir=tempd)
+        worker = w.create_worker("myfile.dat", target, append=False)
         assert isinstance(worker, threading.Thread)
-        w("myfile2.dat", tempd, "test")
+        w("myfile2.dat", "test")
         w.finalize()
 
 
 def test_thread_writer_fail():
-    w = writing.ThreadWriter(savefun=None)
     with tempfile.TemporaryDirectory() as tempd:
-        w("myfile2.dat", tempd, "test")
+        w = writing.ThreadWriter(savefun=None, out_dir=tempd)
+        w("myfile2.dat", "test")
         with pytest.raises(RuntimeError):
             w.finalize()
 
 
 def test_process_writer_create_worker():
     target = mock.MagicMock()
-    w = writing.ProcessWriter()
     with tempfile.TemporaryDirectory() as tempd:
-        worker = w.create_worker("myfile.dat", tempd, target, append=False)
+        w = writing.ProcessWriter(out_dir=tempd)
+        worker = w.create_worker("myfile.dat", target, append=False)
         assert isinstance(worker, multiprocessing.Process)
-        w("myfile2.dat", tempd, "test")
+        w("myfile2.dat", "test")
         w.finalize()
 
 
 def test_process_writer_fail():
-    w = writing.ProcessWriter(savefun=None)
     with tempfile.TemporaryDirectory() as tempd:
-        w("myfile2.dat", tempd, "test")
+        w = writing.ProcessWriter(savefun=None, out_dir=tempd)
+        w("myfile2.dat", "test")
         with pytest.raises(RuntimeError):
             w.finalize()
 
@@ -82,11 +85,10 @@ def test_queue_writer():
     ]
     with mock.patch(names[0], return_value=q):
         with mock.patch(names[1], return_value=consumer):
-            w = writing.QueueWriter()
-
             with tempfile.TemporaryDirectory() as tempd:
-                w("myfile.dat", tempd, target)
-                w("myfile.dat", tempd, target)
+                w = writing.QueueWriter(out_dir=tempd)
+                w("myfile.dat", target)
+                w("myfile.dat", target)
                 w.finalize()
 
             assert consumer.start.call_count == 1

--- a/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/test_manager.py
@@ -527,7 +527,11 @@ def test_extensions_accessing_models_without_flag(priority):
     if priority is not None:
         extension.priority = priority
     manager = training.ExtensionsManager(
-        m, optimizer, 1, iters_per_epoch=5, extensions=[extension]
+        m,
+        optimizer,
+        1,
+        iters_per_epoch=5,
+        extensions=[extension],
     )
     while not manager.stop_trigger:
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
Remove the out_dir argument of Writer.__call__ since it does not affect the behavior of the program.