### PR TITLE
Add wait_for_first_optimizer_step mode

### DIFF
--- a/pytorch_pfn_extras/training/extensions/lr_scheduler.py
+++ b/pytorch_pfn_extras/training/extensions/lr_scheduler.py
@@ -48,6 +48,9 @@ class LRScheduler(extension.Extension):
         stepper (callable): Function that performs the step on
             the scheduler.
         trigger: Frequency to call this extension.
+        wait_for_first_optimizer_step (bool): Wait until optimizer.step is called
+            before invoking scheduler.step. This can address the issue where
+            optimizer.step is not called from the first iteration when using GradScaler.
     """
 
     def __init__(
@@ -56,14 +59,25 @@ class LRScheduler(extension.Extension):
         *,
         stepper: Any = _default_stepper,
         trigger: trigger_module.TriggerLike = (1, "epoch"),
+        wait_for_first_optimizer_step: bool = False,
         is_async: bool = True,
     ) -> None:
         self.scheduler = scheduler
         self.trigger = trigger_module.get_trigger(trigger)
         self.stepper = stepper
+        self.wait_for_first_optimizer_step = wait_for_first_optimizer_step
+        self._stepped = False
         self.is_async = is_async
 
     def __call__(self, manager: ExtensionsManagerProtocol) -> None:
+        if not self._stepped:
+            if (
+                self.wait_for_first_optimizer_step
+                and self.scheduler.optimizer._step_count < 1
+            ):
+                return
+            self._stepped = True
+
         self.stepper(manager, self.scheduler)
 
     @staticmethod

--- a/pytorch_pfn_extras/training/extensions/lr_scheduler.py
+++ b/pytorch_pfn_extras/training/extensions/lr_scheduler.py
@@ -71,12 +71,12 @@ class LRScheduler(extension.Extension):
     def __call__(self, manager: ExtensionsManagerProtocol) -> None:
         # https://github.com/pytorch/pytorch/blob/v2.0.1/torch/optim/lr_scheduler.py#L137-L138
         if (
-            self.scheduler.optimizer._step_count < 1
-            and self.wait_for_first_optimizer_step
+            self.wait_for_first_optimizer_step
+            and hasattr(self.scheduler.optimizer.step, "_with_counter")
+            and self.scheduler.optimizer._step_count < 1
         ):
             return
-        if self.scheduler.optimizer._step_count > 0:
-            self.stepper(manager, self.scheduler)
+        self.stepper(manager, self.scheduler)
 
     @staticmethod
     def step_by_value(key: Optional[str]) -> Any:

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_lr_scheduler.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_lr_scheduler.py
@@ -128,3 +128,24 @@ def test_lr_scheduler_wait_for_first_optimizer_step():
             pass
 
     assert stepper.call_count == 8
+
+
+def test_wait_for_first_optimizer_step_with_non_torch_lr_scheduler():
+    param = torch.nn.Parameter(torch.zeros(10))
+    optim = torch.optim.SGD([param], 1.0)
+    sched = MagicMock()
+    sched.optimizer = optim
+    stepper = MagicMock()
+    ext = ppe.training.extensions.LRScheduler(
+        sched,
+        stepper=stepper,
+        wait_for_first_optimizer_step=True,
+        trigger=(1, "iteration"),
+    )
+    manager = ppe.training.ExtensionsManager(
+        {}, {}, 1, extensions=[ext], iters_per_epoch=40
+    )
+    for i in range(4):
+        with manager.run_iteration():
+            pass
+    assert stepper.call_count == 4


### PR DESCRIPTION
We will add a mode to delay the execution of scheduler.step until optimizer.step is run. This is to prevent a PyTorch warning that can occur when scheduler.step is executed before optimizer.step, a situation that can arise when GradScaler does not execute optimizer.step on the first iteration.






