### PR TITLE
Fix float epoch trigger

### DIFF
--- a/pytorch_pfn_extras/training/triggers/interval_trigger.py
+++ b/pytorch_pfn_extras/training/triggers/interval_trigger.py
@@ -77,7 +77,7 @@ class IntervalTrigger(trigger.Trigger):
             else:
                 return self.period == 0
         if self.unit == "epoch":
-            fire = (iteration % (epoch_length * self.period)) == 0
+            fire = (iteration % (epoch_length * self.period)) < 1
         else:
-            fire = (iteration % self.period) == 0
+            fire = (iteration % self.period) < 1
         return fire

--- a/tests/pytorch_pfn_extras_tests/training_tests/triggers_tests/test_interval_trigger.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/triggers_tests/test_interval_trigger.py
@@ -9,6 +9,12 @@ _argvalues = [
     (1, (3, "epoch"), [False, False, True, False, False, True, False], 4),
     # fractional epoch
     (2, (1.5, "epoch"), [False, False, True, False, False, True, False], 4),
+    (
+        3,
+        (1.5, "epoch"),
+        [False, False, False, False, True, False, False, False, True],
+        4,
+    ),
 ]
 
 


### PR DESCRIPTION
When the trigger is given as a float in epoch units, there can be cases where it may not function correctly. Thus, we will make necessary adjustments to correct this.