### PR TITLE
Ignore BrokenBarrierError in comparer test

### DIFF
--- a/pytorch_pfn_extras/utils/comparer.py
+++ b/pytorch_pfn_extras/utils/comparer.py
@@ -294,6 +294,8 @@ class _ComparerBase:
             with self.report_lock:
                 self._finalized = True
                 self._assert_incompatible_trigger(len(self.targets) == 0)
+        except threading.BrokenBarrierError:
+            pass
         except Exception:
             self.barrier.abort()
             raise
@@ -747,6 +749,8 @@ class Comparer:
             with self._report_lock:
                 self._finalized = True
                 self._assert_incompatible_trigger(len(self._targets) == 0)
+        except threading.BrokenBarrierError:
+            pass
         except Exception:
             self._barrier.abort()
             raise


### PR DESCRIPTION
Fix https://github.com/pfnet/pytorch-pfn-extras/issues/791.

`OutputsComparer` compares calculation results on all workers in parallel. If the check fails on a thread, the threads raises an AssertionError and destroys the threading.Barrier, and the waiting threads raise a `BrokenBarrierError` stochastically.