### PR TITLE
Fix nightly test

### DIFF
--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_lr_scheduler.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_lr_scheduler.py
@@ -58,7 +58,7 @@ def test_reduce_lr_on_plateau():
     param = torch.nn.Parameter(torch.zeros(10))
     optim = torch.optim.SGD([param], 1.0)
     sched = torch.optim.lr_scheduler.ReduceLROnPlateau(
-        optim, patience=1, verbose=True
+        optim, patience=1
     )
     ext = ppe.training.extensions.LRScheduler(sched, trigger=(1, "iteration"))
 
@@ -87,7 +87,7 @@ def test_reduce_lr_on_plateau_no_report():
     param = torch.nn.Parameter(torch.zeros(10))
     optim = torch.optim.SGD([param], 1.0)
     sched = torch.optim.lr_scheduler.ReduceLROnPlateau(
-        optim, patience=1, verbose=True
+        optim, patience=1
     )
     ext = ppe.training.extensions.LRScheduler(sched, trigger=(1, "iteration"))
 

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_lr_scheduler.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_lr_scheduler.py
@@ -57,9 +57,7 @@ def test_serialize_scheduler():
 def test_reduce_lr_on_plateau():
     param = torch.nn.Parameter(torch.zeros(10))
     optim = torch.optim.SGD([param], 1.0)
-    sched = torch.optim.lr_scheduler.ReduceLROnPlateau(
-        optim, patience=1
-    )
+    sched = torch.optim.lr_scheduler.ReduceLROnPlateau(optim, patience=1)
     ext = ppe.training.extensions.LRScheduler(sched, trigger=(1, "iteration"))
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -86,9 +84,7 @@ def test_reduce_lr_on_plateau():
 def test_reduce_lr_on_plateau_no_report():
     param = torch.nn.Parameter(torch.zeros(10))
     optim = torch.optim.SGD([param], 1.0)
-    sched = torch.optim.lr_scheduler.ReduceLROnPlateau(
-        optim, patience=1
-    )
+    sched = torch.optim.lr_scheduler.ReduceLROnPlateau(optim, patience=1)
     ext = ppe.training.extensions.LRScheduler(sched, trigger=(1, "iteration"))
 
     manager = ppe.training.ExtensionsManager(


### PR DESCRIPTION
close #792 

In the latest pytorch, the `verbose` option argument of `torch.optim.lr_scheduler.ReduceLROnPlateau() `was deprecated.

https://github.com/pytorch/pytorch/blob/bbc39b7bb48d28d67e3253a89cc82df3687ddd1b/torch/optim/lr_scheduler.py#L989-L994