### PR TITLE
Use argument `out_dir` not `self.out_dir`

### DIFF
--- a/pytorch_pfn_extras/writing/_writer_base.py
+++ b/pytorch_pfn_extras/writing/_writer_base.py
@@ -286,7 +286,6 @@ class Writer:
         append: bool,
         **savefun_kwargs: Any,
     ) -> None:
-        out_dir = self.out_dir
         if not self._initialized:
             self.initialize(out_dir)
 


### PR DESCRIPTION
I'm not sure this is intended, but the currently we cannot specify `out_dir` from the argument because `self.out_dir` is always used.