### PR TITLE
Allow running nightly CI against pull requests

### DIFF
--- a/.github/workflows/nightly-test-cpu.yml
+++ b/.github/workflows/nightly-test-cpu.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.8'
 

--- a/.github/workflows/nightly-test-cpu.yml
+++ b/.github/workflows/nightly-test-cpu.yml
@@ -3,7 +3,11 @@ name: "Nightly CPU Tests"
 on:
   schedule:
   - cron: 0 0 * * *
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Commit or branch to test (e.g., refs/pull/1234/merge)'
+        type: string
 
 jobs:
   nightly-test:
@@ -15,6 +19,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
+        ref: ${{ inputs.ref || github.ref }}
         submodules: recursive
 
     - name: Setup Python


### PR DESCRIPTION
To test #815, allow manually-triggering nightly CI against pull requests.

Also bump action versions.
