### PR TITLE
Add export_testcase to support length 1 arrays and lists

### DIFF
--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -427,6 +427,10 @@ def export_testcase(
     for pb_name in glob.glob(os.path.join(data_set_path, "*.pb")):
         os.remove(pb_name)
     for i, (arg, name) in enumerate(zip(named_args, input_names)):
+        if isinstance(arg, (list, tuple)):
+            assert len(arg) == 1, \
+                'Models that receive nested lists/tuples are not supported yet'
+            arg = arg[0]
         f = os.path.join(data_set_path, 'input_{}.pb'.format(i))
         write_to_pb(f, arg, name)
 

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
@@ -636,7 +636,6 @@ def test_export_tuple_input():
     model = Net()
     x = torch.rand(2, 5)
 
-    # Test with labels
     export_testcase(
         model,
         ((x,),),

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
@@ -617,3 +617,32 @@ def test_export_default_kwargs():
     )
 
     check_inputs(output_dir, ["x", "bias"])
+
+
+def test_export_tuple_input():
+
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(5, 10, bias=False)
+            self.in_channels = [5, 10]
+
+        def forward(self, inputs):
+            assert isinstance(inputs, tuple), f"{type(inputs)=}"
+            linears = [self.linear(x) for x in inputs]
+            return linears
+
+
+    model = Net()
+    x = torch.rand(2, 5)
+
+    # Test with labels
+    export_testcase(
+        model,
+        ((x,),),
+        output_dir,
+        input_names=["x"],
+        training=model.training,
+        do_constant_folding=False,
+        opset_version=12,
+    )


### PR DESCRIPTION
# Problem

The output allows a tuple or list of length 1, but not input.


# Reproduction

checkout 8defb94d093be26ccec2af3d4dc41d0c4c4283d0 and run
```
pytest tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py -k test_export_tuple_input
```

# This PR

Add processing equivalent to output to input.