### PR TITLE
Avoid using `pkg_resources`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,9 +2,6 @@
 filterwarnings =
     error
 
-    ### Workaround for pkg_resources bug
-    ignore::DeprecationWarning:pkg_resources
-
     ### Workaround specific to Windows
     # pandas seems to be built with minimum supported NumPy version (1.15.4), raising a warning in newer NumPy
     ignore:numpy.ufunc size changed, may indicate binary incompatibility:RuntimeWarning:

--- a/pytorch_pfn_extras/_torch_version.py
+++ b/pytorch_pfn_extras/_torch_version.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.metadata
 
 from packaging.version import Version
 

--- a/pytorch_pfn_extras/_torch_version.py
+++ b/pytorch_pfn_extras/_torch_version.py
@@ -1,12 +1,8 @@
+import importlib
+
 from packaging.version import Version
 
 
 def requires(version: str, package: str = "torch") -> bool:
-    if package == "torch":
-        import torch as module
-    elif package == "onnx":
-        import onnx as module
-    else:
-        raise ValueError(f"Unsupported package: {package}")
-    pkg_ver = module.__version__
+    pkg_ver = importlib.metadata.version(package)
     return Version(pkg_ver.split("+")[0].split("-")[0]) >= Version(version)

--- a/pytorch_pfn_extras/_torch_version.py
+++ b/pytorch_pfn_extras/_torch_version.py
@@ -1,7 +1,12 @@
-import pkg_resources
 from packaging.version import Version
 
 
 def requires(version: str, package: str = "torch") -> bool:
-    pkg_ver = pkg_resources.get_distribution(package).version
+    if package == "torch":
+        import torch as module
+    elif package == "onnx":
+        import onnx as module
+    else:
+        raise ValueError(f"Unsupported package: {package}")
+    pkg_ver = module.__version__
     return Version(pkg_ver.split("+")[0].split("-")[0]) >= Version(version)


### PR DESCRIPTION
`pkg_resources` is deprecated. https://setuptools.pypa.io/en/latest/pkg_resources.html