### PR TITLE
ignore warning about weights_only flag

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -35,6 +35,8 @@ filterwarnings =
     ignore:torch.library.impl_abstract was renamed to torch.library.register_fake.:DeprecationWarning
     # For torch >= 2.4 nightly: torch.profiler.profile maybe temporarily broken
     ignore:The None is not a valid device option.:UserWarning
+    # For torch >= 2.4: It is difficult to foresee loading a malicious file, so we will continue using the default value.
+    ignore:You are using `torch.load` with `weights_only=False`:FutureWarning
 markers =
     gpu: Tests that require GPU
     mpi: Tests that require MPI

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py
@@ -159,11 +159,9 @@ class LazyTestBase:
             torch.save(model_src.state_dict(), f.name)
             if not init_src and init_dst:
                 with pytest.raises(RuntimeError):
-                    model_dst.load_state_dict(
-                        torch.load(f.name, weights_only=True)
-                    )
+                    model_dst.load_state_dict(torch.load(f.name))
             else:
-                model_dst.load_state_dict(torch.load(f.name, weights_only=True))
+                model_dst.load_state_dict(torch.load(f.name))
 
         # Ensure that if the model was initialized, the parameters are the same
         # after loading a state dict

--- a/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py
+++ b/tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py
@@ -159,9 +159,11 @@ class LazyTestBase:
             torch.save(model_src.state_dict(), f.name)
             if not init_src and init_dst:
                 with pytest.raises(RuntimeError):
-                    model_dst.load_state_dict(torch.load(f.name))
+                    model_dst.load_state_dict(
+                        torch.load(f.name, weights_only=True)
+                    )
             else:
-                model_dst.load_state_dict(torch.load(f.name))
+                model_dst.load_state_dict(torch.load(f.name, weights_only=True))
 
         # Ensure that if the model was initialized, the parameters are the same
         # after loading a state dict


### PR DESCRIPTION
depends: #830 

To avoid the warning 
```
FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value),...... 
```
when using pytest, I will add filter in pytest.ini