### PR TITLE
[ONNX] Flatten input test data to support nested inputs

### DIFF
--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -422,11 +422,8 @@ def export_testcase(
     os.makedirs(data_set_path, exist_ok=True)
     for pb_name in glob.glob(os.path.join(data_set_path, "*.pb")):
         os.remove(pb_name)
-    for i, (arg, name) in enumerate(zip(named_args, input_names)):
-        if isinstance(arg, (list, tuple)):
-            assert len(arg) == 1, \
-                'Models that receive nested lists/tuples are not supported yet'
-            arg = arg[0]
+    flat_inputs = torch._C._jit_flatten(named_args)[0]
+    for i, (arg, name) in enumerate(zip(flat_inputs, input_names)):
         f = os.path.join(data_set_path, 'input_{}.pb'.format(i))
         write_to_pb(f, arg, name)
 

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -423,6 +423,10 @@ def export_testcase(
     for pb_name in glob.glob(os.path.join(data_set_path, "*.pb")):
         os.remove(pb_name)
     for i, (arg, name) in enumerate(zip(named_args, input_names)):
+        if isinstance(arg, (list, tuple)):
+            assert len(arg) == 1, \
+                'Models that receive nested lists/tuples are not supported yet'
+            arg = arg[0]
         f = os.path.join(data_set_path, 'input_{}.pb'.format(i))
         write_to_pb(f, arg, name)
 

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
@@ -633,3 +633,32 @@ def test_custom_exporter():
     actual = ort_session.run(None, {"x": x.cpu().numpy()})[0]
     expected = model(x)
     np.testing.assert_allclose(actual, expected.detach().numpy(), atol=1e-3)
+
+
+def test_export_tuple_input():
+
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(5, 10, bias=False)
+            self.in_channels = [5, 10]
+
+        def forward(self, inputs):
+            assert isinstance(inputs, tuple), f"{type(inputs)=}"
+            linears = [self.linear(x) for x in inputs]
+            return linears
+
+
+    model = Net()
+    x = torch.rand(2, 5)
+
+    # Test with labels
+    export_testcase(
+        model,
+        ((x,),),
+        output_dir,
+        input_names=["x"],
+        training=model.training,
+        do_constant_folding=False,
+        opset_version=12,
+    )

--- a/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
+++ b/tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py
@@ -652,7 +652,6 @@ def test_export_tuple_input():
     model = Net()
     x = torch.rand(2, 5)
 
-    # Test with labels
     export_testcase(
         model,
         ((x,),),


### PR DESCRIPTION
Original codes are from @impactaky -san. Thank you!

See also https://github.com/pfnet/pytorch-pfn-extras/pull/822