### PR TITLE
Fix ONNX export for compatibility with PyTorch 2.6

### DIFF
--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -130,6 +130,12 @@ def _export_util(
         checker_error = getattr(torch.onnx, "CheckerError", None)
         if checker_error is None:
             checker_error = getattr(torch.onnx.utils, "ONNXCheckerError", None)  # type: ignore[attr-defined]
+        if checker_error is None:
+            # PyTorch 2.6 does not have either of exception classes above.
+            # As check by onnx.checker has been removed we no longer need to
+            # capture the exception.
+            class checker_error(RuntimeError):
+                pass
         try:
             enable_onnx_checker = kwargs.pop('enable_onnx_checker', None)
             if pytorch_pfn_extras.requires("2.5.0") and enable_onnx_checker:

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -134,7 +134,7 @@ def _export_util(
             # PyTorch 2.6 does not have either of exception classes above.
             # As check by onnx.checker has been removed we no longer need to
             # capture the exception.
-            class checker_error(RuntimeError):
+            class checker_error(RuntimeError):  # type: ignore[no-redef]
                 pass
         try:
             enable_onnx_checker = kwargs.pop('enable_onnx_checker', None)

--- a/pytorch_pfn_extras/onnx/export_testcase.py
+++ b/pytorch_pfn_extras/onnx/export_testcase.py
@@ -170,7 +170,6 @@ def _export(
             if kwargs["training"] \
             else torch.onnx.TrainingMode.EVAL
 
-    original_log = torch.onnx.log  # type: ignore[attr-defined]
     if opset_ver is None:
         opset_ver = pytorch_pfn_extras.onnx._constants.onnx_default_opset
         kwargs['opset_version'] = opset_ver
@@ -179,8 +178,12 @@ def _export(
         kwargs['strip_doc_string'] = False
     else:
         strip_doc_string = kwargs.pop('strip_doc_string', True)
-        if not kwargs.get('verbose', False):
+        if (not kwargs.get('verbose', False) and
+                not pytorch_pfn_extras.requires("2.6.0")):
+            # torch.onnx.log was removed in PyTorch 2.6.0.
+            # https://github.com/pytorch/pytorch/pull/133825
             force_verbose = True
+            original_log = torch.onnx.log  # type: ignore[attr-defined]
             #  Following line won't work because verbose mode always
             # enable logging so we are replacing python function instead:
             # torch.onnx.disable_log()


### PR DESCRIPTION
xref #602 and #843 (cc/ @take-cheeze)

### `torch.onnx.log`

`torch.onnx.log` was removed in https://github.com/pytorch/pytorch/pull/133825

As of PyTorch 2.5 and 2.6, it seems no verbose logs are emitted to stdout. I confirmed PyTorch 2.3.1 emits logs like following, so keeping this code path for now.

```
STAGE:2025-03-24 07:50:31 1576104:1576104 ActivityProfilerController.cpp:314] Completed Stage: Warm Up
STAGE:2025-03-24 07:50:31 1576104:1576104 ActivityProfilerController.cpp:320] Completed Stage: Collection
STAGE:2025-03-24 07:50:31 1576104:1576104 ActivityProfilerController.cpp:324] Completed Stage: Post Processing
```

I confirmed `python -m pytest -s -v tests/pytorch_pfn_extras_tests/onnx_tests/test_export_testcase.py` pass in my local with PyTorch 2.6.

### `checker_error`

It seems PyTorch 2.5+ no longer calls `onnx.checker` (which is called behind `torch._C._check_onnx_proto`) (https://github.com/pytorch/pytorch/pull/135180), and the exception classes were also removed accordingly. The fix in #843 caused `checker_error` to become None, but this crashes with error `catching classes that do not inherit from BaseException is not allowed` if exceptions are raised for other reasons.