### PR TITLE
Support PyTorch 2.6 & better compatibility with NumPy 2

### DIFF
--- a/pytorch_pfn_extras/dataset/shared_dataset.py
+++ b/pytorch_pfn_extras/dataset/shared_dataset.py
@@ -43,6 +43,8 @@ class InfiniteCache(Cache):
         return x
 
     def add_to_cache(self, idx, x):
+        if isinstance(x, torch.Tensor):
+            x = x.detach().cpu().numpy()
         self.storage[idx] = x
         self.cached_ids[idx] = 1
 

--- a/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
+++ b/pytorch_pfn_extras/training/extensions/variable_statistics_plot.py
@@ -100,6 +100,8 @@ class Reservoir:
         self.counter = 0
 
     def add(self, x: Any, idx: Any = None) -> None:
+        if isinstance(x, torch.Tensor):
+            x = x.detach().cpu().numpy()
         if self.counter < self.size:
             self.data[self.counter] = x
             self.idxs[self.counter] = idx or self.counter

--- a/tests/pytorch_pfn_extras_tests/runtime_tests/test_to.py
+++ b/tests/pytorch_pfn_extras_tests/runtime_tests/test_to.py
@@ -97,7 +97,7 @@ def test_save_module():
     ppe.to(module, "dummy", runtime_class=NonPicklableRuntime)
     bio = io.BytesIO()
     torch.save(module, bio)
-    module2 = torch.load(io.BytesIO(bio.getvalue()))
+    module2 = torch.load(io.BytesIO(bio.getvalue()), weights_only=False)
     assert module.state_dict().keys() == module2.state_dict().keys()
     for k in module.state_dict().keys():
         assert torch.all(module.state_dict()[k] == module2.state_dict()[k])
@@ -106,5 +106,5 @@ def test_save_module():
     ppe.to(module, "dummy", runtime_class=NonPicklableRuntime)
     bio = io.BytesIO()
     torch.save(module, bio)
-    module2 = torch.load(io.BytesIO(bio.getvalue()))
+    module2 = torch.load(io.BytesIO(bio.getvalue()), weights_only=False)
     assert module2.v == 20

--- a/tests/pytorch_pfn_extras_tests/test_reporter.py
+++ b/tests/pytorch_pfn_extras_tests/test_reporter.py
@@ -477,7 +477,7 @@ def test_dict_summary_serialize_names_with_delimiter(
         assert transfer_protocol == "torch"
         f = io.BytesIO()
         torch.save(summary, f)
-        summary2 = torch.load(io.BytesIO(f.getvalue()))
+        summary2 = torch.load(io.BytesIO(f.getvalue()), weights_only=False)
     summary2.add({key1: 3.0, key2: 5.0, key3: 8.0})
 
     _check_dict_summary(

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_evaluator.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_evaluator.py
@@ -72,7 +72,7 @@ def test_evaluate(evaluator_dummies):
         )
 
     numpy.testing.assert_almost_equal(
-        mean["target/loss"], expect_mean, decimal=4
+        mean["target/loss"].numpy(), expect_mean, decimal=4
     )
 
 
@@ -82,7 +82,8 @@ def test_metric(evaluator_dummies):
     mean = evaluator()
     # 'main' is used by default
     assert "custom-metric" in mean
-    numpy.testing.assert_almost_equal(mean["main/loss"], expect_mean, decimal=4)
+    numpy.testing.assert_almost_equal(
+        mean["main/loss"].numpy(), expect_mean, decimal=4)
 
 
 def test_call(evaluator_dummies):
@@ -90,7 +91,8 @@ def test_call(evaluator_dummies):
 
     mean = evaluator()
     # 'main' is used by default
-    numpy.testing.assert_almost_equal(mean["main/loss"], expect_mean, decimal=4)
+    numpy.testing.assert_almost_equal(
+        mean["main/loss"].numpy(), expect_mean, decimal=4)
 
 
 def test_evaluator_name(evaluator_dummies):
@@ -100,7 +102,7 @@ def test_evaluator_name(evaluator_dummies):
     mean = evaluator()
     # name is used as a prefix
     numpy.testing.assert_almost_equal(
-        mean["eval/main/loss"], expect_mean, decimal=4
+        mean["eval/main/loss"].numpy(), expect_mean, decimal=4
     )
 
 
@@ -144,7 +146,7 @@ def test_evaluator_tuple_data():
 
     expect_mean = numpy.mean([numpy.sum(x) for x in data])
     numpy.testing.assert_almost_equal(
-        mean["target/loss"], expect_mean, decimal=4
+        mean["target/loss"].numpy(), expect_mean, decimal=4
     )
 
 
@@ -179,7 +181,7 @@ def test_evaluator_dict_data():
         [numpy.sum(x["x"]) + numpy.sum(x["y"]) for x in data]
     )
     numpy.testing.assert_almost_equal(
-        mean["target/loss"], expect_mean, decimal=4
+        mean["target/loss"].numpy(), expect_mean, decimal=4
     )
 
 

--- a/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_evaluator.py
+++ b/tests/pytorch_pfn_extras_tests/training_tests/extensions_tests/test_evaluator.py
@@ -83,7 +83,8 @@ def test_metric(evaluator_dummies):
     # 'main' is used by default
     assert "custom-metric" in mean
     numpy.testing.assert_almost_equal(
-        mean["main/loss"].numpy(), expect_mean, decimal=4)
+        mean["main/loss"].numpy(), expect_mean, decimal=4
+    )
 
 
 def test_call(evaluator_dummies):
@@ -92,7 +93,8 @@ def test_call(evaluator_dummies):
     mean = evaluator()
     # 'main' is used by default
     numpy.testing.assert_almost_equal(
-        mean["main/loss"].numpy(), expect_mean, decimal=4)
+        mean["main/loss"].numpy(), expect_mean, decimal=4
+    )
 
 
 def test_evaluator_name(evaluator_dummies):


### PR DESCRIPTION
* PyTorch 2.6 now defaults to `weights_only=True` when `torch.load`: https://pytorch.org/blog/pytorch2-6/
* PyTorch's Array interface (`__array__ `) is not yet compatible with NumPy 2: https://github.com/pytorch/pytorch/issues/136264